### PR TITLE
Add @flow to index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+// @flow
 // Copyright (c) 2015 Uber Technologies, Inc.
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Hi!
I just started using react-map-gl for a project I'm doing, where I'm also using flow. In order to do so, I had to create a stub for react-map-gl declaring all types to be any.
However, I just realized that the library is already flow typed, which is awesome, but flow still complains that I'm exporting from an untyped module.
Looking into #681, it seems I'm not the only one who noticed this. I'm not sure if this would solve the issue or what is the proper way to expose these types to the consumers but if it is not I would be happy to help if someone points me in the right direction.