### PR TITLE
Feature/maprefprovider

### DIFF
--- a/src/components/map-provider.js
+++ b/src/components/map-provider.js
@@ -1,0 +1,51 @@
+// @flow
+import React, {useState, useContext, createContext} from 'react';
+import MapContext from './map-context';
+import WebMercatorViewport from 'viewport-mercator-project';
+import {Map} from 'mapbox-gl';
+
+type MapProviderProps = {
+  defaultViewport: ?WebMercatorViewport
+};
+
+const SetMapContext = createContext(undefined);
+
+const MapProvider: React$ComponentType<MapProviderProps> = ({defaultViewport, children}) => {
+  /** Store viewport in state */
+  const [viewport, setViewport] = useState<typeof undefined | WebMercatorViewport>(undefined);
+
+  /** Store viewport in state */
+  const [mapRef, setMapRef] = useState<typeof undefined | Map>(undefined);
+
+  return (
+    <MapContext.Provider
+      value={{
+        viewport,
+        map: mapRef,
+        eventManager: null,
+        isDragging: false,
+        mapContainer: null,
+        onViewStateChange: setViewport,
+        onViewportChange: setViewport
+      }}
+    >
+      <SetMapContext.Provider value={{setViewport, setMapRef}}>{children}</SetMapContext.Provider>
+    </MapContext.Provider>
+  );
+};
+
+export default MapProvider;
+
+/** Hook to expose the MapContext */
+export const useMap = () => {
+  const context = useContext(MapContext);
+  if (!context) throw Error('Not inside <MapProvider />');
+  return context;
+};
+
+/** Split out state updaters into it's own hook to prevent unnecessary re-renders (when viewport changes, often). */
+export const useSetMap = () => {
+  const context = useContext(SetMapContext);
+  if (!context) throw Error('Not inside <MapProvider />');
+  return context;
+};

--- a/src/components/use-map-ref.js
+++ b/src/components/use-map-ref.js
@@ -1,11 +1,14 @@
-import MapContext from './map-context';
+// @flow
+
 import {useContext} from 'react';
+import Mapbox from '../mapbox/mapbox';
+import MapContext from './map-context';
 
 /**
  * Hook to access underlying Mapbox instance. Use only available
  * inside a child component of InteractiveMap or StaticMap.
  */
-export const useMapRef = () => {
+export const useMapRef = (): Mapbox | null => {
   const context = useContext(MapContext);
   if (!context) throw Error('Trying to useMapRef outside of MapContext.');
   return context.map;

--- a/src/components/use-map-ref.js
+++ b/src/components/use-map-ref.js
@@ -1,0 +1,12 @@
+import MapContext from './map-context';
+import {useContext} from 'react';
+
+/**
+ * Hook to access underlying Mapbox instance. Use only available
+ * inside a child component of InteractiveMap or StaticMap.
+ */
+export const useMapRef = () => {
+  const context = useContext(MapContext);
+  if (!context) throw Error('Trying to useMapRef outside of MapContext.');
+  return context.map;
+};

--- a/test/src/components/map-provider.js
+++ b/test/src/components/map-provider.js
@@ -1,0 +1,35 @@
+import test from 'tape-catch';
+import {MapContext, MapProvider} from 'react-map-gl';
+import * as React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import WebMercatorViewport from 'viewport-mercator-project';
+
+const testCase = (
+  <MapProvider>
+    <MapContext.Consumer>
+      {({viewport, map}) => (
+        <>
+          <div className="viewport">viewport: {JSON.stringify(viewport)}</div>
+          <div className="map">map: {JSON.stringify(map)}</div>
+        </>
+      )}
+    </MapContext.Consumer>
+  </MapProvider>
+);
+
+test.only('MapProvider - Provides a default viewport', t => {
+  const DEFUALT_VIEWPORT = {latitude: -37, longitude: 144, zoom: 15};
+  const result = ReactTestRenderer.create(
+    <MapProvider defaultViewport={new WebMercatorViewport(DEFUALT_VIEWPORT)}>
+      {testCase}
+    </MapProvider>
+  );
+
+  const resultRoot = result.root;
+
+  /** Assert the viewport is coming through the context consumer. */
+  t.ok(
+    resultRoot.findByProps('className', 'viewport').children[0],
+    `viewport: ${JSON.stringify(DEFUALT_VIEWPORT)}`
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,7 +3612,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3665,11 +3665,6 @@ deep-equal@^1.0.1, deep-equal@~1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3787,11 +3782,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -5464,7 +5454,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5567,7 +5557,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6955,15 +6945,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -7067,22 +7048,6 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
@@ -7159,7 +7124,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -7184,7 +7149,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8176,16 +8141,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-dom@^16.3.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -8732,11 +8687,6 @@ samsam@1.x:
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
   integrity sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==
 
-sax@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
 saxes@^3.1.9:
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-3.1.11.tgz#d59d1fd332ec92ad98a2e0b2ee644702384b1c5b"
@@ -8781,7 +8731,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -9419,11 +9369,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 strong-log-transformer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
@@ -9524,7 +9469,7 @@ tape@^4.9.2:
     string.prototype.trim "~1.2.1"
     through "~2.3.8"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Hey @Pessimistress, I'm opening this early so we can discuss API et al before I go too deep in a solution that isn't compatible with the direction of the package.

The main benefit of this hook, in my experience, is to be able to access the mapbox instance anywhere in your app. At present (the way MapContext) is used, it's only possible to access the mapbox ref from a child of either `<InteractiveMap />` or `<StaticMap />` (as MapContext is only provided within those components).

Looking forward to further hook implementation, I've also found it beneficial to be able to do other things like set the viewport from elsewhere in the app. I've outlined how I approach this here: https://github.com/visgl/react-map-gl/issues/904#issuecomment-539689479. 

Essentially there are three components:
1. `<MapProvider />` (name is arbitrary at this state, MapHookProvider, MapRefProvider, etc)
2. `useMapRef` hook that consumes this provider (or useViewport, etc)
3. A wrapped `<StaticMap />` that uses the onLoad prop to store the mapbox ref in the context.

The main concern, I can imagine, is introducing greater API surface. I guess, are you OK introducing a public context provider to allow storing the ref and providing it to the hook?

What I have pushed so far will work, however, it'll only be accessible within the two map components. It will throw an error when used outside.

If you're happy with the additional public provider, I can go ahead and create it. I can then set the mapbox ref in StaticMap within the (private) `MapContext.Consumer` here:

https://github.com/visgl/react-map-gl/blob/15ae86247b934cd0a43f0eba1cb109c74c3eee6b/src/components/static-map.js#L264

My understanding is that this will bubble up for `InteractiveMap` as well.

Let me know.