### PR TITLE
[Geolocate] Auto trigger when component loads

### DIFF
--- a/docs/api-reference/geolocate-control.md
+++ b/docs/api-reference/geolocate-control.md
@@ -45,13 +45,13 @@ Callback when Geolocation API position updates. It is called with a Geolocation 
 
 ##### `positionOptions` (Object)
 
-- default: `{enableHighAccuracy: false, timeout: 6000}` 
+- default: `{enableHighAccuracy: false, timeout: 6000}`
 
 A Geolocation API [PositionOptions](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions) object.
 
 ##### `fitBoundsOptions` (Object)
 
-- default: `{maxZoom: 15}` 
+- default: `{maxZoom: 15}`
 
 A [fitBounds](https://docs.mapbox.com/mapbox-gl-js/api/#map#fitbounds) options object to use when the map is panned and zoomed to the user's location. The default is to use a  maxZoom of 15 to limit how far the map will zoom in for very accurate locations.
 
@@ -78,6 +78,12 @@ Check [`locate user`](https://github.com/visgl/react-map-gl/tree/5.2-release/exa
 - default: `Geolocate`
 
 Label applied to the Geolocate control button.
+
+##### `auto` (Boolean)
+
+- default: `false`
+
+Auto trigger geolocate on successful loading of component
 
 
 ## Styling

--- a/docs/api-reference/geolocate-control.md
+++ b/docs/api-reference/geolocate-control.md
@@ -83,7 +83,7 @@ Label applied to the Geolocate control button.
 
 - default: `false`
 
-Auto trigger geolocate on successful loading of component
+Auto trigger geolocate on successful mounting of component
 
 
 ## Styling

--- a/src/components/geolocate-control.js
+++ b/src/components/geolocate-control.js
@@ -121,6 +121,14 @@ export default class GeolocateControl extends BaseControl<
     });
   }
 
+  componentDidUpdate(prevProps: GeolocateControlProps) {
+    // trigger geolocate when prop auto changes to true
+    // change to false has no effect
+    if (this.state.supportsGeolocation && !prevProps.auto && this.props.auto) {
+      this._triggerGeolocate();
+    }
+  }
+
   componentWillUnmount() {
     // re-implement MapboxGeolocateControl's _onRemove
     // clear the geolocation watch if exists

--- a/src/components/geolocate-control.js
+++ b/src/components/geolocate-control.js
@@ -28,6 +28,8 @@ const propTypes = Object.assign({}, BaseControl.propTypes, {
   style: PropTypes.object,
   // Custom label assigned to the control
   label: PropTypes.string,
+  // Auto trigger instead of waiting for click
+  auto: PropTypes.bool,
 
   // mapbox geolocate options
   // https://docs.mapbox.com/mapbox-gl-js/api/#geolocatecontrol
@@ -48,6 +50,7 @@ const defaultProps = Object.assign({}, BaseControl.defaultProps, {
   className: '',
   style: {},
   label: 'Geolocate',
+  auto: false,
 
   // mapbox geolocate options
   positionOptions: null,
@@ -62,6 +65,7 @@ export type GeolocateControlProps = BaseControlProps & {
   className: string,
   style: Object,
   label: string,
+  auto: boolean,
   positionOptions: any,
   fitBoundsOptions: any,
   trackUserLocation: boolean,
@@ -111,6 +115,9 @@ export default class GeolocateControl extends BaseControl<
     isGeolocationSupported().then(result => {
       this.setState({supportsGeolocation: result});
       this._setupMapboxGeolocateControl(result);
+      if (this.props.auto) {
+        this._triggerGeolocate();
+      }
     });
   }
 
@@ -182,7 +189,7 @@ export default class GeolocateControl extends BaseControl<
     control.on('geolocate', this.props.onGeolocate);
   };
 
-  _onClickGeolocate = () => {
+  _triggerGeolocate = () => {
     const control = this._mapboxGeolocateControl;
     control._map = this._context.map;
 
@@ -285,7 +292,7 @@ export default class GeolocateControl extends BaseControl<
           style={style}
           onContextMenu={e => e.preventDefault()}
         >
-          {this._renderButton('geolocate', label, this._onClickGeolocate)}
+          {this._renderButton('geolocate', label, this._triggerGeolocate)}
         </div>
       </div>
     );


### PR DESCRIPTION
This PR brings a functionality parallel to https://github.com/mapbox/mapbox-gl-js/issues/5464 which was addressed by exposing a `trigger()` method in https://github.com/mapbox/mapbox-gl-js/pull/6205.

To achieve the same in the react way, added a new property `auto` to the Geolocate component which when set to true, automatically geolocates the user on the map (when permission granted), similar to what happens when the geolocate button is clicked. I feel this is an important feature to bring this library in parity with the other available map libraries.

If I missed an edge case or if there is a better way to get this done, would be happy to make the changes.

<img src="https://user-images.githubusercontent.com/1571586/83341169-269ef580-a295-11ea-8c81-2c6b46a05e4e.gif" width=1500/>
