### PR TITLE
Check if map style is loaded before removing source or layer

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -104,7 +104,7 @@ export default class Layer<Props: LayerProps> extends PureComponent<Props> {
     const map = this._map;
     if (map) {
       map.off('styledata', this._updateLayer);
-      if (map.style) {
+      if (map.style && map.style._loaded) {
         map.removeLayer(this.id);
       }
     }

--- a/src/components/source.js
+++ b/src/components/source.js
@@ -58,9 +58,11 @@ export default class Source<Props: SourceProps> extends PureComponent<Props> {
     const map = this._map;
     if (map) {
       map.off('styledata', this._updateSource);
-      if (map.style) {
-        requestAnimationFrame(() => map.removeSource(this.id));
-      }
+      requestAnimationFrame(() => {
+        if (map.style && map.style._loaded) {
+          map.removeSource(this.id);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Avoids "Style is not done loading" error

Resolves #1122 

Although I was unable to reproduce #1122 in our application on every attempt (it depends on the timing of styles being loaded), with this change I could not reproduce it. 