### PR TITLE
[geolocate] fix auto when location blocked

### DIFF
--- a/examples/controls/src/app.js
+++ b/examples/controls/src/app.js
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import {Component} from 'react';
 import {render} from 'react-dom';
-import MapGL, {Popup, NavigationControl, FullscreenControl, ScaleControl} from 'react-map-gl';
+import MapGL, {
+  Popup,
+  NavigationControl,
+  FullscreenControl,
+  ScaleControl,
+  GeolocateControl
+} from 'react-map-gl';
 
 import ControlPanel from './control-panel';
 import Pins from './pins';
@@ -11,16 +17,23 @@ import CITIES from '../../.data/cities.json';
 
 const TOKEN = ''; // Set your mapbox token here
 
-const fullscreenControlStyle = {
+const geolocateStyle = {
   position: 'absolute',
   top: 0,
   left: 0,
   padding: '10px'
 };
 
-const navStyle = {
+const fullscreenControlStyle = {
   position: 'absolute',
   top: 36,
+  left: 0,
+  padding: '10px'
+};
+
+const navStyle = {
+  position: 'absolute',
+  top: 72,
   left: 0,
   padding: '10px'
 };
@@ -90,6 +103,9 @@ export default class App extends Component {
 
         {this._renderPopup()}
 
+        <div style={geolocateStyle}>
+          <GeolocateControl />
+        </div>
         <div style={fullscreenControlStyle}>
           <FullscreenControl />
         </div>

--- a/src/components/geolocate-control.js
+++ b/src/components/geolocate-control.js
@@ -115,7 +115,7 @@ export default class GeolocateControl extends BaseControl<
     isGeolocationSupported().then(result => {
       this.setState({supportsGeolocation: result});
       this._setupMapboxGeolocateControl(result);
-      if (this.props.auto) {
+      if (result && this.props.auto) {
         this._triggerGeolocate();
       }
     });


### PR DESCRIPTION
fixing my bad. sorry, this will need a hot fix due to the breaking change.

wasn't using the result from `isGeolocationSupported()` in `componentDidMount()` when triggering geolocate. This is causing a crash when the location access is blocked by the browser. Also, updated the controls example to include geocontrol.

<img width="1038" alt="Screen Shot 2020-06-04 at 10 04 35 PM" src="https://user-images.githubusercontent.com/1571586/83840038-652c1a00-a6b2-11ea-861d-6f075dd60475.png">
