### PR TITLE
Always rerender overlay after map initialization

### DIFF
--- a/src/components/static-map.js
+++ b/src/components/static-map.js
@@ -256,8 +256,8 @@ export default class StaticMap extends PureComponent<StaticMapProps, State> {
     return null;
   }
 
-  _renderOverlays(dimensions: {width?: number, height?: number}) {
-    const {width = Number(this.props.width), height = Number(this.props.height)} = dimensions;
+  _renderOverlays(dimensions: {width: number, height: number}) {
+    const {width, height} = dimensions;
     this._updateMapSize(width, height);
 
     return (
@@ -307,12 +307,7 @@ export default class StaticMap extends PureComponent<StaticMapProps, State> {
         <div key="map-mapbox" ref={this._mapboxMapRef} style={mapStyle} className={className} />
         {/* AutoSizer is a pure component and does not rerender when map props change */}
         {/* rebind the callback so that it's triggered every render pass */}
-        <AutoSizer
-          key="autosizer"
-          disableWidth={Number.isFinite(width)}
-          disableHeight={Number.isFinite(height)}
-          onResize={this.props.onResize}
-        >
+        <AutoSizer key="autosizer" onResize={this.props.onResize}>
           {this._renderOverlays.bind(this)}
         </AutoSizer>
         {this._renderNoTokenWarning()}


### PR DESCRIPTION
For https://github.com/visgl/react-map-gl/issues/1168

Issue:

- If either width or height is relative, `_renderOverlays` (`AutoResizer`'s child) is called when dimension is resolved, which happens to be after mount, and `this._map` is populated.
- If both `disableWidth` or `disableHeight` are `true`, `_renderOverlays` is called immediately, before `this._map` is available, causing the map instance to be missing from the context.

This PR removes the usage of `disableWidth`/`disableHeight`