### PR TITLE
Replace react resizer with ResizeObserver

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,6 @@
 [ignore]
 .*/examples/
-.*/node_modules/
+.*/node_modules/@mapbox
 
 [include]
 ./src/

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mapbox-gl": "^1.0.0",
     "mjolnir.js": "^2.4.0",
     "prop-types": "^15.7.2",
-    "react-virtualized-auto-sizer": "^1.0.2",
+    "resize-observer-polyfill": "^1.5.1",
     "viewport-mercator-project": "^6.2.3 || ^7.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8130,11 +8130,6 @@ react-test-renderer@^16.3.0:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react-virtualized-auto-sizer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
-  integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
-
 react@^16.3.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -8479,6 +8474,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
[ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) is available in all evergreen browsers. [resize-observer-polyfill](https://www.npmjs.com/package/resize-observer-polyfill) offers implementation for IE11, old Edge and some mobile browsers.

I expect the native API implementation to be more efficient than the React component using extra CSS/onscroll event listeners. `resize-observer-polyfill` is also a more widely used dependency than `react-virtualized-auto-sizer`.