### PR TITLE
Update Source docs

### DIFF
--- a/docs/api-reference/source.md
+++ b/docs/api-reference/source.md
@@ -8,6 +8,12 @@ This component allows apps to create a [map source](https://docs.mapbox.com/mapb
 import * as React from 'react';
 import ReactMapGL, {Source, Layer} from 'react-map-gl';
 
+const EMPTY_STYLE = {
+  version: 8,
+  sources: {},
+  layers: []
+};
+
 const geojson = {
   type: 'FeatureCollection',
   features: [
@@ -18,7 +24,7 @@ const geojson = {
 class Map extends React.Component {
   render() {
     return (
-      <ReactMapGL latitude={37.78} longitude={-122.41} zoom={8}>
+      <ReactMapGL latitude={37.78} longitude={-122.41} zoom={8} mapStyle={EMPTY_STYLE}>
         <Source id="my-data" type="geojson" data={geojson}>
           <Layer
             id="point"
@@ -38,7 +44,9 @@ class Map extends React.Component {
 
 The props provided to this component should be conforming to the [Mapbox source specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/#sources)or [CanvasSourceOptions](https://docs.mapbox.com/mapbox-gl-js/api/#canvassourceoptions).
 
-When props change *shallowly*, the component will attempt to update the source. Do not define objects/arrays inline to avoid perf hit.
+[mapStyle](https://visgl.github.io/react-map-gl/docs/api-reference/static-map#mapstyle) defaults to `mapbox://styles/mapbox/light-v8` which requires a token, to use an empty base map, you need to override the prop. See the `EMPTY_STYLE` object in the example.
+
+When props change _shallowly_, the component will attempt to update the source. Do not define objects/arrays inline to avoid perf hit.
 
 Once a `<Source>` is mounted, the following props should not change. If add/remove multiple JSX sources dynamically, make sure you use React's [key prop](https://reactjs.org/docs/lists-and-keys.html#keys) to give each element a stable identity.
 


### PR DESCRIPTION
[Source](https://visgl.github.io/react-map-gl/docs/api-reference/source) documentation is updated with an example of how to use `ReactMapGL` with `Source` and `Layer` components without a Mapbox token.

Closes  #1178