### PR TITLE
Add types for layer type and source-layer

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -27,34 +27,30 @@ import deepEqual from '../utils/deep-equal';
 
 import type {MapContextProps} from './map-context';
 
+const LAYER_TYPES = {
+  fill: 'fill',
+  line: 'line',
+  symbol: 'symbol',
+  circle: 'circle',
+  fillExtrusion: 'fill-extrusion',
+  raster: 'raster',
+  background: 'background',
+  heatmap: 'heatmap',
+  hillshade: 'hillshade'
+};
+
 const propTypes = {
-  type: PropTypes.oneOf([
-    'fill',
-    'line',
-    'symbol',
-    'circle',
-    'fill-extrusion',
-    'raster',
-    'background',
-    'heatmap',
-    'hillshade'
-  ]).isRequired,
+  type: PropTypes.oneOf(Object.keys(LAYER_TYPES)).isRequired,
   id: PropTypes.string,
   source: PropTypes.string,
   beforeId: PropTypes.string
 };
 
+export type LayerTypes = $Keys<typeof LAYER_TYPES>;
+
 type LayerProps = {
   id?: string,
-  type: | 'fill'
-    | 'line'
-    | 'symbol'
-    | 'circle'
-    | 'fill-extrusion'
-    | 'raster'
-    | 'background'
-    | 'heatmap'
-    | 'hillshade',
+  type: LayerTypes,
   source?: string,
   'source-layer'?: string,
   beforeId?: string,

--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -28,7 +28,17 @@ import deepEqual from '../utils/deep-equal';
 import type {MapContextProps} from './map-context';
 
 const propTypes = {
-  type: PropTypes.string.isRequired,
+  type: PropTypes.oneOf([
+    'fill',
+    'line',
+    'symbol',
+    'circle',
+    'fill-extrusion',
+    'raster',
+    'background',
+    'heatmap',
+    'hillshade'
+  ]).isRequired,
   id: PropTypes.string,
   source: PropTypes.string,
   beforeId: PropTypes.string
@@ -36,8 +46,17 @@ const propTypes = {
 
 type LayerProps = {
   id?: string,
-  type: string,
+  type: | 'fill'
+    | 'line'
+    | 'symbol'
+    | 'circle'
+    | 'fill-extrusion'
+    | 'raster'
+    | 'background'
+    | 'heatmap'
+    | 'hillshade',
   source?: string,
+  'source-layer'?: string,
   beforeId?: string,
   layout: any,
   paint: any,


### PR DESCRIPTION
This addresses the missing prop type for `source-layer` brought up in #1114 
If needed I can also address #1047 if you think paint should not be required.

When testing I could not get the prettier check to pass however it did not show me any specific errors. Any advice about what I can do about that would be appreciated.