### PR TITLE
Fix for layout and paint diffing logic

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -54,20 +54,28 @@ function diffLayerStyles(map: any, id: string, props: LayerProps, prevProps: Lay
     map.moveLayer(id, beforeId);
   }
   if (layout !== prevProps.layout) {
-    const keys = new Set([...Object.keys(layout), ...Object.keys(prevProps.layout)]);
-    keys.forEach(key => {
+    for (const key in layout) {
       if (!deepEqual(layout[key], prevProps.layout[key])) {
         map.setLayoutProperty(id, key, layout[key]);
       }
-    });
+    }
+    for (const key in prevProps.layout) {
+      if (!layout.hasOwnProperty(key)) {
+        map.setLayoutProperty(id, key, undefined);
+      }
+    }
   }
   if (paint !== prevProps.paint) {
-    const keys = new Set([...Object.keys(paint), ...Object.keys(prevProps.paint)]);
-    keys.forEach(key => {
+    for (const key in paint) {
       if (!deepEqual(paint[key], prevProps.paint[key])) {
         map.setPaintProperty(id, key, paint[key]);
       }
-    });
+    }
+    for (const key in prevProps.paint) {
+      if (!paint.hasOwnProperty(key)) {
+        map.setPaintProperty(id, key, undefined);
+      }
+    }
   }
   if (!deepEqual(filter, prevProps.filter)) {
     map.setFilter(id, filter);

--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -54,18 +54,20 @@ function diffLayerStyles(map: any, id: string, props: LayerProps, prevProps: Lay
     map.moveLayer(id, beforeId);
   }
   if (layout !== prevProps.layout) {
-    for (const key in layout) {
+    const keys = new Set([...Object.keys(layout), ...Object.keys(prevProps.layout)]);
+    keys.forEach(key => {
       if (!deepEqual(layout[key], prevProps.layout[key])) {
         map.setLayoutProperty(id, key, layout[key]);
       }
-    }
+    });
   }
   if (paint !== prevProps.paint) {
-    for (const key in paint) {
+    const keys = new Set([...Object.keys(paint), ...Object.keys(prevProps.paint)]);
+    keys.forEach(key => {
       if (!deepEqual(paint[key], prevProps.paint[key])) {
         map.setPaintProperty(id, key, paint[key]);
       }
-    }
+    });
   }
   if (!deepEqual(filter, prevProps.filter)) {
     map.setFilter(id, filter);


### PR DESCRIPTION
Fixes #1193

Say we have a layer with this paint
```json
{
  "paint": {
    "text-halo-width": 8,
    "text-halo-color": "#c52020",
    "text-color": "#000000"
  }
}
```
and we change that to 
```json
{
  "paint": {
    "text-color": "#000000"
  }
}
```
The expected behavior is the text to have no halo with the second config, but the red halo stays.
This _should_ set the key to undefined with 
```javascript
map.setPaintProperty(id, "text-halo-color", undefined);
map.setPaintProperty(id, "text-halo-width", undefined);
```