### PR TITLE
Use valid fill-extrusion value for layer type

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -32,7 +32,7 @@ const LAYER_TYPES = {
   line: 'line',
   symbol: 'symbol',
   circle: 'circle',
-  fillExtrusion: 'fill-extrusion',
+  'fill-extrusion': 'fill-extrusion',
   raster: 'raster',
   background: 'background',
   heatmap: 'heatmap',


### PR DESCRIPTION
This fixes the PropType definition for the `fill-extrusion` layer type.

Prior to this fix, the value is required to be `fillExtrusion`. Mapbox expects to see `fill-extrusion` instead, and throws an error.