### PR TITLE
Add capturePointerMove to NavigationControl

### DIFF
--- a/docs/advanced/custom-components.md
+++ b/docs/advanced/custom-components.md
@@ -53,7 +53,7 @@ Stop propagation of click event to the map component. Can be used to stop map fr
 Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.
 
 ##### `capturePointerMove` {Boolean} - default: `false`
-Stop propagation of pointermove event to the map component. Can be used to stop map from calling the `onMouseMove` or `onTouchMove` callback when this component is clicked.
+Stop propagation of pointermove event to the map component. Can be used to stop map from calling the `onMouseMove` or `onTouchMove` callback when this component is hovered.
 
 ## Private Members
 

--- a/docs/advanced/custom-components.md
+++ b/docs/advanced/custom-components.md
@@ -52,6 +52,9 @@ Stop propagation of click event to the map component. Can be used to stop map fr
 ##### `captureDoubleClick` {Boolean} - default: `true`
 Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.
 
+##### `capturePointerMove` {Boolean} - default: `false`
+Stop propagation of pointermove event to the map component.  Can be used to stop map from calling the `onHover` callback when this component is clicked.
+
 ## Private Members
 
 ##### `_containerRef`

--- a/docs/advanced/custom-components.md
+++ b/docs/advanced/custom-components.md
@@ -53,7 +53,7 @@ Stop propagation of click event to the map component. Can be used to stop map fr
 Stop propagation of dblclick event to the map component. Can be used to stop map from zooming when this component is double clicked.
 
 ##### `capturePointerMove` {Boolean} - default: `false`
-Stop propagation of pointermove event to the map component.  Can be used to stop map from calling the `onHover` callback when this component is clicked.
+Stop propagation of pointermove event to the map component. Can be used to stop map from calling the `onMouseMove` or `onTouchMove` callback when this component is clicked.
 
 ## Private Members
 

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -33,14 +33,17 @@ const propTypes = {
   // Stop map click
   captureClick: PropTypes.bool,
   // Stop map double click
-  captureDoubleClick: PropTypes.bool
+  captureDoubleClick: PropTypes.bool,
+  // Stop map pointer move
+  capturePointerMove: PropTypes.bool
 };
 
 const defaultProps = {
   captureScroll: false,
   captureDrag: true,
   captureClick: true,
-  captureDoubleClick: true
+  captureDoubleClick: true,
+  capturePointerMove: true
 };
 
 export type BaseControlProps = {
@@ -48,6 +51,7 @@ export type BaseControlProps = {
   captureDrag: boolean,
   captureClick: boolean,
   captureDoubleClick: boolean,
+  capturePointerMove: Boolean,
   children?: any
 };
 
@@ -81,7 +85,8 @@ export default class BaseControl<
         panstart: this._onDragStart,
         anyclick: this._onClick,
         click: this._onClick,
-        dblclick: this._onDblClick
+        dblclick: this._onDblClick,
+        pointermove: this._onPointerMove
       };
       eventManager.watch(this._events, ref);
     }
@@ -118,6 +123,12 @@ export default class BaseControl<
 
   _onClick = (evt: MjolnirEvent) => {
     if (this.props.captureClick) {
+      evt.stopPropagation();
+    }
+  };
+
+  _onPointerMove = (evt: MjolnirEvent) => {
+    if (this.props.capturePointerMove) {
       evt.stopPropagation();
     }
   };

--- a/src/components/base-control.js
+++ b/src/components/base-control.js
@@ -43,7 +43,7 @@ const defaultProps = {
   captureDrag: true,
   captureClick: true,
   captureDoubleClick: true,
-  capturePointerMove: true
+  capturePointerMove: false
 };
 
 export type BaseControlProps = {
@@ -51,7 +51,7 @@ export type BaseControlProps = {
   captureDrag: boolean,
   captureClick: boolean,
   captureDoubleClick: boolean,
-  capturePointerMove: Boolean,
+  capturePointerMove: boolean,
   children?: any
 };
 

--- a/src/overlays/canvas-overlay.js
+++ b/src/overlays/canvas-overlay.js
@@ -34,7 +34,8 @@ const defaultProps = {
   captureScroll: false,
   captureDrag: false,
   captureClick: false,
-  captureDoubleClick: false
+  captureDoubleClick: false,
+  capturePointerMove: false
 };
 
 export type CanvasOverlayProps = BaseControlProps & {

--- a/src/overlays/html-overlay.js
+++ b/src/overlays/html-overlay.js
@@ -35,7 +35,8 @@ const defaultProps = {
   captureScroll: false,
   captureDrag: false,
   captureClick: false,
-  captureDoubleClick: false
+  captureDoubleClick: false,
+  capturePointerMove: false
 };
 
 export type HTMLOverlayProps = BaseControlProps & {

--- a/src/overlays/svg-overlay.js
+++ b/src/overlays/svg-overlay.js
@@ -35,7 +35,8 @@ const defaultProps = {
   captureScroll: false,
   captureDrag: false,
   captureClick: false,
-  captureDoubleClick: false
+  captureDoubleClick: false,
+  capturePointerMove: false
 };
 
 export type SVGOverlayProps = BaseControlProps & {


### PR DESCRIPTION
As described in this issue https://github.com/visgl/deck.gl/issues/5095

When the map is behind the `NavigationControl` and accepts the `onHover` event it is triggered when clicking on the navigation button. This PR prevents the event from being triggered.