### PR TITLE
Use pull_request instead of pull_request_target for Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
     - master
-  pull_request_target:
+  pull_request:
 
 jobs:
   test-node:


### PR DESCRIPTION
As noted by @Pessimistress, the existing Github Actions setup is defined incorrectly and _doesn't actually run on the pull request's changes_.

> the breakage happened in the functional component PRs, for which CI passed. Then when they are merged into master, master failed. My PR to fix it also failed, but once it's merged master passed

![image](https://user-images.githubusercontent.com/15164633/101568009-13c95400-398f-11eb-8d58-d2158c0a3ce0.png)

The issue here is my misreading of [Github's blog post](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/). In my quick read of that post, I saw "the workflow is running from a trusted source" when using `pull_request_target` and figured that was strictly better than using `pull_request`.

It turns out that `pull_request_target` is _intended only for commenting/tagging the issue/PR_. 

> In order to protect public repositories for malicious users we run all pull request workflows raised from repository forks with a read-only token and no access to secrets. This makes common workflows like labeling or commenting on pull requests very difficult.

> In order to solve this, …

you use a `pull_request_target`. So for our purposes we should always be using `pull_request`.

I'll make PRs for deck.gl and loaders.gl as well.