### PR TITLE
Fix dynamic position offscreen

### DIFF
--- a/src/utils/dynamic-position.js
+++ b/src/utils/dynamic-position.js
@@ -71,10 +71,6 @@ export function getDynamicPosition({
     }
   }
 
-  // anchorX: left - 0, center - 0.5, right - 1
-  let left = x - anchorX * selfWidth;
-  let right = left + selfWidth;
-
   // If needed, adjust anchorX at 0.5 step between [0, 1]
   let xStep = 0.5;
   if (anchorY === 0.5) {
@@ -82,6 +78,10 @@ export function getDynamicPosition({
     anchorX = Math.floor(anchorX);
     xStep = 1;
   }
+
+  // anchorX: left - 0, center - 0.5, right - 1
+  let left = x - anchorX * selfWidth;
+  let right = left + selfWidth;
 
   if (left < padding) {
     // Left edge is outside, try move right

--- a/test/src/utils/dynamic-position.spec.js
+++ b/test/src/utils/dynamic-position.spec.js
@@ -33,6 +33,19 @@ const TEST_CASES = [
   },
   {
     opts: {
+      height: 720,
+      padding: 10,
+      selfHeight: 589,
+      selfWidth: 620,
+      width: 1216,
+      x: 771.00000000002,
+      y: 400.9999999999942
+    },
+    expected: (input, output) => output === 'right',
+    message: 'Overwhelmingly large container'
+  },
+  {
+    opts: {
       x: 50,
       y: 50,
       width: 100,


### PR DESCRIPTION
In some cases, the Popup container with dynamic positioning was showing up offscreen in a project. 

This tended to happen with:
* Large Popups (h > window/2, w =~ window/2)
* Anchored near the middle of the screen

The large popups need to be anchored by the left/right middle, as anchoring to the top or bottom causes the popup to go off screen. 

This PR fixes this behavior by moving the "If y is centered, then x cannot also be centered" block ahead of the point where the left and right positions are calculated. A test is included. 


(Notes: 
 * I don't think the tests do what they're intended to do. My test passed when comparing to 'right' and 'xright'.
 * Perhaps running the tests before checking for lint would make iterations faster, or perhaps not worry about lint until a check in hook. Also, if lint is that required, maybe automatically run it. 
 * The commit hooks that take 30 seconds to run _really_ slow down rebases to change wording. 
)
