### PR TITLE
Add support for 'sky' layer type to Layer component

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -33,7 +33,8 @@ const LAYER_TYPES = {
   raster: 'raster',
   background: 'background',
   heatmap: 'heatmap',
-  hillshade: 'hillshade'
+  hillshade: 'hillshade',
+  sky: 'sky'
 };
 
 const propTypes = {


### PR DESCRIPTION
Addresses #1267. Removes incorrect `Invalid prop type` warning when Layer component prop type is set to `sky`.