### PR TITLE
Feature/allow user to set compact attribution

### DIFF
--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -273,7 +273,15 @@ export default class Mapbox {
       if (props.transformRequest) {
         mapOptions.transformRequest = props.transformRequest;
       }
-      this._map = new this.mapboxgl.Map(Object.assign({}, mapOptions, props.mapOptions));
+
+      this._map = new this.mapboxgl.Map(Object.assign({}, mapOptions, props.mapOptions))
+
+      if(props.mapOptions.compact) {
+        this._map.addControl(new this.mapboxgl.AttributionControl({
+          compact: props.mapOptions.compact,
+          customAttribution: props.mapOptions.customAttribution
+        }));    
+      }
 
       // Attach optional onLoad function
       this._map.once('load', props.onLoad);

--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -274,13 +274,15 @@ export default class Mapbox {
         mapOptions.transformRequest = props.transformRequest;
       }
 
-      this._map = new this.mapboxgl.Map(Object.assign({}, mapOptions, props.mapOptions))
+      this._map = new this.mapboxgl.Map(Object.assign({}, mapOptions, props.mapOptions));
 
-      if(props.mapOptions.compact) {
-        this._map.addControl(new this.mapboxgl.AttributionControl({
-          compact: props.mapOptions.compact,
-          customAttribution: props.mapOptions.customAttribution
-        }));    
+      if (props.mapOptions.compact) {
+        this._map.addControl(
+          new this.mapboxgl.AttributionControl({
+            compact: props.mapOptions.compact,
+            customAttribution: props.mapOptions.customAttribution
+          })
+        );
       }
 
       // Attach optional onLoad function


### PR DESCRIPTION
Address part of #1129 to allow the user to set the map attribution to the compact size.

I did not update to include the request to `not just add to the default attributions but customize it completely` as this does not match the API behaviour from mapbox js.