### PR TITLE
Add attribution control to typescript index exports

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,6 +29,7 @@ export {default as Layer} from './components/layer';
 export {default as BaseControl} from './components/base-control';
 export {default as Marker} from './components/marker';
 export {default as Popup} from './components/popup';
+export {default as AttributionControl} from './components/attribution-control';
 export {default as FullscreenControl} from './components/fullscreen-control';
 export {default as GeolocateControl} from './components/geolocate-control';
 export {default as NavigationControl} from './components/navigation-control';


### PR DESCRIPTION
Fixes the following error:

`Module '"../../node_modules/react-map-gl/src"' has no exported member 'AttributionControl'. Did you mean to use 'import AttributionControl from "../../node_modules/react-map-gl/src"' instead?`