### PR TITLE
Set scrollZoom.smooth default to false

### DIFF
--- a/docs/api-reference/interactive-map.md
+++ b/docs/api-reference/interactive-map.md
@@ -109,7 +109,7 @@ Min pitch in degrees.
 Enable scroll to zoom. If an object is provided, may contain the following options to customize the scroll zoom behavior:
 
 - `speed` (Number) - Multiplier for the wheel delta. Default `0.01`.
-- `smooth` (Number) - Smoothly transition to the new zoom. If enabled, will provide a slightly lagged but smoother experience. Default `true`.
+- `smooth` (Boolean) - Smoothly transition to the new zoom. If enabled, will provide a slightly lagged but smoother experience. Default `false`.
 
 ##### `dragPan` (Boolean|Object)
 
@@ -410,4 +410,3 @@ Inherit the following methods from [StaticMap](/docs/api-reference/static-map.md
 ## Source
 
 [interactive-map.js](https://github.com/visgl/react-map-gl/tree/6.0-release/src/components/interactive-map.js)
-

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,14 +4,13 @@
 
 - `MapContext` is now an official API. The experimental `_MapContext` export will be removed in a future release.
 - `react-virtualized-auto-sizer` is no longer a dependency.
-- Inertia and smooth zooming has been enabled by default on the map controller. To revert to the behavior in previous versions, set the [interaction options](/docs/api-reference/interactive-map.md#interaction-options):
+- Inertia has been enabled by default on the map controller. To revert to the behavior in previous versions, set the [interaction options](/docs/api-reference/interactive-map.md#interaction-options):
 
 ```js
 const CONTROLLER_OPTS = {
   dragPan: {inertia: 0},
   dragRotate: {inertia: 0},
-  touchZoom: {inertia: 0},
-  scrollZoom: {smooth: false}
+  touchZoom: {inertia: 0}
 };
 
 <MapGL {...CONTROLLER_OPTS} ... />

--- a/src/utils/map-controller.js
+++ b/src/utils/map-controller.js
@@ -375,7 +375,7 @@ export default class MapController {
       return false;
     }
 
-    const {speed = 0.01, smooth = true} = this.scrollZoom;
+    const {speed = 0.01, smooth = false} = this.scrollZoom;
 
     event.preventDefault();
 


### PR DESCRIPTION
For #1316

Smooth zooming is very slow using trackpad. While we work to address this issue, disable smooth zooming by default (prev release behavior).