### PR TITLE
Use dedicated secret for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MapboxAccessToken: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+      MapboxAccessToken: ${{ secrets.MAPBOX_ACCESS_TOKEN_CI }}
 
     steps:
       - uses: actions/checkout@v2.1.1


### PR DESCRIPTION
We have restricted the origin URL for the public website token