### PR TITLE
Fix react error when Source has no children

### DIFF
--- a/src/components/source.js
+++ b/src/components/source.js
@@ -131,16 +131,18 @@ function Source(props) {
   }
   propsRef.current = props;
 
-  return source
-    ? React.Children.map(
+  return (
+    (source &&
+      React.Children.map(
         props.children,
         child =>
           child &&
           cloneElement(child, {
             source: id
           })
-      )
-    : null;
+      )) ||
+    null
+  );
 }
 
 Source.propTypes = propTypes;


### PR DESCRIPTION
For #1340

`React.Children.map` returns `undefined` if `props.children` is `undefined`.