### PR TITLE
Fix missing source-layer param in LayerProps

### DIFF
--- a/src/components/layer.d.ts
+++ b/src/components/layer.d.ts
@@ -5,6 +5,7 @@ export interface LayerProps {
   id?: string;
   type:  'fill' | 'line' | 'symbol' | 'circle' | 'fill-extrusion' | 'raster' | 'background' | 'heatmap' | 'hillshade' | 'sky';
   source?: string;
+  'source-layer'?: string,
   beforeId?: string;
   layout?: MapboxGL.AnyLayout;
   paint:


### PR DESCRIPTION
Source layer is a required parameter for vector types. It was accidentally removed as part of a refactor in https://github.com/visgl/react-map-gl/pull/1308. Also noted in following comment. https://github.com/visgl/react-map-gl/commit/7d2b56e2422a07bda59eb96a4a6755e4743d31f5#r46750244