### PR TITLE
Improve typescript bindings

### DIFF
--- a/src/components/interactive-map.d.ts
+++ b/src/components/interactive-map.d.ts
@@ -9,8 +9,8 @@ type State = {
 };
 
 export type MapEvent = MjolnirEvent & {
-  point: Array<number>,
-  lngLat: Array<number>,
+  point: [x: number, y: number],
+  lngLat: [longitude: number, latitude: number],
   features?: Array<any>
 };
 

--- a/src/utils/map-controller.d.ts
+++ b/src/utils/map-controller.d.ts
@@ -5,18 +5,22 @@ export type MjolnirEvent = {
   type: string,
   center: {x: number, y: number},
   offsetCenter: {x: number, y: number},
-  deltaX: number,
-  deltaY: number,
-  delta: number,
-  scale: number,
-  rotation: number,
-  pointerType: string,
-  metaKey: boolean,
-  rightButton: boolean,
-  stopPropagation: Function,
-  preventDefault: Function,
+  deltaX?: number,
+  deltaY?: number,
+  delta?: number,
+  scale?: number,
+  rotation?: number,
+  pointerType?: string,
+  metaKey?: boolean,
+  key?: number,
+  leftButton?: boolean,
+  middleButton?: boolean,
+  rightButton?: boolean,
+  stopPropagation: () => void,
+  stopImmediatePropagation: () => void,
+  preventDefault: () => void,
   target: HTMLElement,
-  srcEvent: any
+  srcEvent: MouseEvent | PointerEvent | TouchEvent
 };
 
 export const LINEAR_TRANSITION_PROPS: any;


### PR DESCRIPTION
- Make MapEvent.point/lngLat 2-arrays
- From MjolnirEvent remove deltaX/deltaY/scale/rotation/metaKey which seem like they might not exist, or at least are not in the public API documentation
- From MjolnirEvent make delta/pointerType/rightButton optional, as the API documentation states they are only present for some events
- From MjolnirEvent add stopImmediatePropagation/leftButton/middleButton/key which are supposed to exist per docs
- From MjolnirEvent make typings for stopPropagation/preventDefault/srcEvent more specific