### PR TITLE
Add promoteId as a source prop

### DIFF
--- a/src/components/source.d.ts
+++ b/src/components/source.d.ts
@@ -26,7 +26,7 @@ export interface SourceProps {
   coordinates?: number[][];
   urls?: string[];
   children?: any;
-
+  promoteId?: string;
 }
 
 export default class Source extends PureComponent<SourceProps> {}


### PR DESCRIPTION
https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson-promoteId

This field is already supported in mapbox for a geojson source. 