### PR TITLE
Making features available to onMouseEnter. This fixes issue 1473

### DIFF
--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -215,15 +215,19 @@ function onPointerMove(event) {
     if (interactiveLayerIds || onHover) {
       features = getFeatures.call(this, event.point);
     }
-    if (onHover) {
-      // backward compatibility: v3 `onHover` interface
-      event.features = features;
-      onHover(event);
-    }
 
     const isHovering = Boolean(interactiveLayerIds && features && features.length > 0);
     const isEntering = isHovering && !this.state.isHovering;
     const isExiting = !isHovering && this.state.isHovering;
+
+    if (onHover || isEntering) {
+      event.features = features;
+
+      // backward compatibility: v3 `onHover` interface
+      if (onHover) { 
+        onHover(event);
+      }
+    }
 
     if (isEntering) {
       onEvent.call(this, 'onMouseEnter', event);

--- a/src/components/interactive-map.js
+++ b/src/components/interactive-map.js
@@ -224,7 +224,7 @@ function onPointerMove(event) {
       event.features = features;
 
       // backward compatibility: v3 `onHover` interface
-      if (onHover) { 
+      if (onHover) {
         onHover(event);
       }
     }


### PR DESCRIPTION
I don't see why you wouldn't want to make features available to onMouseEnter. The event isn't very useful if you have to go and query again for what is under the mouse. This code remedies that by simply including that object on the event.