### PR TITLE
Prevent attribution button from submitting forms

### DIFF
--- a/src/components/attribution-control.js
+++ b/src/components/attribution-control.js
@@ -79,6 +79,7 @@ function AttributionControl(props) {
         }`}
       >
         <button
+          type="button"
           className="mapboxgl-ctrl-attrib-button"
           title={props.toggleLabel}
           onClick={toggleAttribution}


### PR DESCRIPTION
If the Map is embedded within a form, clicking the attribution button submits it by default.
By explicitly declaring it as a "button" and not "submit", we ensure that doesn't happen.

For details see https://stackoverflow.com/a/10836076/6995854