### PR TITLE
Fix stale `onLoad` and `onError` event handlers

### DIFF
--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -204,6 +204,11 @@ export default class Mapbox {
     });
   };
 
+  _handleError = event => {
+    // @ts-ignore
+    this.props.onError(event);
+  };
+
   _reuse(props) {
     this._map = Mapbox.savedMap;
     // When reusing the saved map, we need to reparent the map(canvas) and other child nodes
@@ -272,8 +277,8 @@ export default class Mapbox {
       this._map = new this.mapboxgl.Map(Object.assign({}, mapOptions, props.mapOptions));
 
       // Attach optional onLoad function
-      this._map.once('load', props.onLoad);
-      this._map.on('error', props.onError);
+      this._map.once('load', this._fireLoadEvent);
+      this._map.on('error', this._handleError);
     }
 
     return this;
@@ -288,8 +293,8 @@ export default class Mapbox {
       Mapbox.savedMap = this._map;
 
       // deregister the mapbox event listeners
-      this._map.off('load', this.props.onLoad);
-      this._map.off('error', this.props.onError);
+      this._map.off('load', this._fireLoadEvent);
+      this._map.off('error', this._handleError);
       this._map.off('styledata', this._fireLoadEvent);
     } else {
       this._map.remove();


### PR DESCRIPTION
The example:

```jsx
const [viewport, setViewport] = useState(DefaultViewport)

const [points, setPoints] = useState([])

useEffect(() => {
  console.log('effect')  
  setPoints(Points) /* the constant defined somewhere */
}, [])

const handleLoad = () => {
  console.log('[load] points.length = %d', points.length)  
  setViewport(panTo(points))
}

const handleError = (e) => {}

return (
  <MapGL
    {...viewport}
    onViewportChange={setViewport}
    onLoad={handleLoad}
    onError={handleError}
  />
)
```

Console (before the fix):
```
effect
[load] points = 0
```

Console (after the fix, expected):

```
effect
[load] points = 1
```

Also it fixes zombie `onError` handler.