### PR TITLE
Omit container prop on mapOptions in types

### DIFF
--- a/src/mapbox/mapbox.d.ts
+++ b/src/mapbox/mapbox.d.ts
@@ -50,7 +50,7 @@ export type MapboxProps = Partial<{
   bearing: number,
   pitch: number,
   altitude: number,
-  mapOptions: MapboxGL.MapboxOptions
+  mapOptions: Omit<MapboxGL.MapboxOptions, 'container'>
 }>;
 
 export default class Mapbox {


### PR DESCRIPTION
react-map-gl does not use the `container` property in `MapboxOptions`, but `MapboxOptions` *requires* this property making it impossible to pass any map options to `ReactMapGL` without breaking it.