### PR TITLE
Fix Popup double onClose call

### DIFF
--- a/src/components/marker.ts
+++ b/src/components/marker.ts
@@ -75,6 +75,9 @@ const defaultProps: Partial<MarkerProps> = {
 
 function Marker(props: MarkerProps) {
   const {map, mapLib} = useContext(MapContext);
+  const thisRef = useRef({props});
+  thisRef.current.props = props;
+
   const marker = useMemo(() => {
     let hasChildren = false;
     React.Children.forEach(props.children, el => {
@@ -87,27 +90,27 @@ function Marker(props: MarkerProps) {
       element: hasChildren ? document.createElement('div') : null
     };
 
-    return new mapLib.Marker(options).setLngLat([props.longitude, props.latitude]);
-  }, []);
-  const thisRef = useRef({props});
-  thisRef.current.props = props;
-
-  useEffect(() => {
-    marker.on('dragstart', e => {
+    const mk = new mapLib.Marker(options).setLngLat([props.longitude, props.latitude]);
+    mk.on('dragstart', e => {
       const evt = e as MarkerDragEvent;
       evt.lngLat = marker.getLngLat();
       thisRef.current.props.onDragStart?.(evt);
     });
-    marker.on('drag', e => {
+    mk.on('drag', e => {
       const evt = e as MarkerDragEvent;
       evt.lngLat = marker.getLngLat();
       thisRef.current.props.onDrag?.(evt);
     });
-    marker.on('dragend', e => {
+    mk.on('dragend', e => {
       const evt = e as MarkerDragEvent;
       evt.lngLat = marker.getLngLat();
       thisRef.current.props.onDragEnd?.(evt);
     });
+
+    return mk;
+  }, []);
+
+  useEffect(() => {
     marker.addTo(map);
 
     return () => {

--- a/src/components/popup.ts
+++ b/src/components/popup.ts
@@ -74,24 +74,28 @@ function Popup(props: PopupProps) {
   const container = useMemo(() => {
     return document.createElement('div');
   }, []);
-  const popup = useMemo(() => {
-    const options = {...props};
-    return new mapLib.Popup(options).setLngLat([props.longitude, props.latitude]);
-  }, []);
   const thisRef = useRef({props});
   thisRef.current.props = props;
 
-  useEffect(() => {
-    popup.on('open', e => {
+  const popup = useMemo(() => {
+    const options = {...props};
+    const pp = new mapLib.Popup(options).setLngLat([props.longitude, props.latitude]);
+    pp.on('open', e => {
       thisRef.current.props.onOpen?.(e as PopupEvent);
     });
-    popup.on('close', e => {
+    pp.on('close', e => {
       thisRef.current.props.onClose?.(e as PopupEvent);
     });
+    return pp;
+  }, []);
+
+  useEffect(() => {
     popup.setDOMContent(container).addTo(map);
 
     return () => {
-      popup.remove();
+      if (popup.isOpen()) {
+        popup.remove();
+      }
     };
   }, []);
 


### PR DESCRIPTION
For #1725 

#### Change list

- Move attaching event listeners to `useMemo` from `useEffect` (called twice in strict mode)
- Do not call `remove()` if popup is already closed on unmount