### PR TITLE
Update links to docs for old versions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,10 @@
     <img src="https://img.shields.io/badge/v7.0-brightgreen.svg?style=flat-square" />
   </a>
   Looking for an old version?
-  <a href="https://github.com/visgl/react-map-gl/tree/7.0-release/docs">
+  <a href="https://github.com/visgl/react-map-gl/tree/6.1-release/docs">
     <img src="https://img.shields.io/badge/v6.1-brightgreen.svg?style=flat-square" />
   </a>
-  <a href="https://github.com/visgl/react-map-gl/tree/7.0-release/docs">
+  <a href="https://github.com/visgl/react-map-gl/tree/5.3-release/docs">
     <img src="https://img.shields.io/badge/v5.3-brightgreen.svg?style=flat-square" />
   </a>
 </p>


### PR DESCRIPTION
- Update badge links for older versions of docs to point to correct release branch
- Previously, v6 and v5 links pointed to v7 release branch