### PR TITLE
Remove optional chained operator

### DIFF
--- a/src/components/use-control.ts
+++ b/src/components/use-control.ts
@@ -18,7 +18,8 @@ export default function useControl<T extends IControl>(
   useEffect(() => {
     const {map} = context;
     if (!map.hasControl(ctrl)) {
-      map.addControl(ctrl, (opts || (onRemove as ControlOptions))?.position);
+      const { position } = opts || (onRemove as ControlOptions) || {}
+      map.addControl(ctrl, position);
     }
 
     return () => {


### PR DESCRIPTION
Currently this library breaks when compiling under `fuse-box` due to an issue with optional chaining (see https://github.com/fuse-box/fuse-box/issues/1981). This removes the one instance that is not handled correctly. This change allows the library to be used with `fuse-box` again (it was unusable since v7), and does not change the logic.