### PR TITLE
[Bug] MarkerProps "onClick" property should be optional

### DIFF
--- a/src/components/marker.ts
+++ b/src/components/marker.ts
@@ -67,7 +67,7 @@ export type MarkerProps = {
   popup?: MapboxPopup;
   /** CSS style override, applied to the control's container */
   style?: React.CSSProperties;
-  onClick: (e: MapboxEvent<MouseEvent>) => void;
+  onClick?: (e: MapboxEvent<MouseEvent>) => void;
   onDragStart?: (e: MarkerDragEvent) => void;
   onDrag?: (e: MarkerDragEvent) => void;
   onDragEnd?: (e: MarkerDragEvent) => void;


### PR DESCRIPTION
Fix for [issue 1788](https://github.com/visgl/react-map-gl/issues/1788).

Changing the property to optional is backwards compatible for anyone using `MarkerProps` so I think this fix is pretty straightforward. Documentation doesn't need updating as `onClick` isn't described as required: https://visgl.github.io/react-map-gl/docs/api-reference/marker#onclick
