### PR TITLE
removed weird type

### DIFF
--- a/src/components/use-map.tsx
+++ b/src/components/use-map.tsx
@@ -51,7 +51,7 @@ export const MapProvider: React.FC<{}> = props => {
   );
 };
 
-export function useMap(): {current?: MapRef; [id: string]: MapRef} {
+export function useMap(): {current?: MapRef} {
   const maps = useContext(MountedMapsContext)?.maps;
   const currentMap = useContext(MapContext);
 


### PR DESCRIPTION
Return type of `useMap()` was breaking builds:

```
node_modules/react-map-gl/dist/esm/components/use-map.d.ts:13:5 - error TS2411: Property 'current' of type 'MapRef | undefined' is not assignable to 'string' index type 'MapRef'.

13     current?: MapRef;
       ~~~~~~~
```