### PR TITLE
Fix rendering issue with globe view at high zoom

### DIFF
--- a/src/mapbox/mapbox.ts
+++ b/src/mapbox/mapbox.ts
@@ -852,7 +852,9 @@ export default class Mapbox {
         // Replace map.transform with ours during the callbacks
         map.transform = this._renderTransform;
         baseFire.call(map, event, properties);
+        const savedProjection = map.transform.projection;
         map.transform = tr;
+        map.transform.projection = savedProjection;
 
         return map;
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,8 @@ export type {
   ScaleControl as MapboxScaleControl
 } from 'mapbox-gl';
 
+import type {ProjectionSpecification} from '../types';
+
 /**
  * Stub for mapbox's Transform class
  * https://github.com/mapbox/mapbox-gl-js/blob/main/src/geo/transform.js
@@ -29,6 +31,7 @@ export type Transform = {
   bearing: number;
   pitch: number;
   padding: PaddingOptions;
+  projection: ProjectionSpecification;
 
   clone: () => Transform;
   resize: (width: number, height: number) => void;


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/11750

In the upcoming globe projection in mapbox-gl-js, the projection automatically transitions to Mercator at high zoom levels. When used with react-map-gl, this created an inconsistent state where between `Mapbox._renderTransform.projection` would be correctly set to Mercator but `Mapbox._map.transform.projection` would be reset to globe at every update, creating strange rendering artifacts.

This PR provides a fix by preserving `projection` from the previous state of the transform.

### Before:

https://user-images.githubusercontent.com/14878684/163887380-fa00ef5b-9b55-4394-938f-4b51fdcd9c31.mov

### After:

https://user-images.githubusercontent.com/14878684/163887390-7bc65cda-9c47-44c9-8c0d-0a687b009cdb.mov