### PR TITLE
 Fix MapProvider prop types

### DIFF
--- a/src/components/use-map.tsx
+++ b/src/components/use-map.tsx
@@ -12,7 +12,7 @@ type MountedMapsContextValue = {
 
 export const MountedMapsContext = React.createContext<MountedMapsContextValue>(null);
 
-export const MapProvider: React.FC<{}> = props => {
+export const MapProvider: React.FC<{children?: React.ReactNode}> = props => {
   const [maps, setMaps] = useState<{[id: string]: MapRef}>({});
 
   const onMapMount = useCallback((map: MapRef, id: string = 'default') => {


### PR DESCRIPTION
As of React 18 (@types/react), `children` is no longer an implicit prop on the React.FunctionComponent type.  This PR adds the type explicitly.  More info here

https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46691
https://solverfox.dev/writing/no-implicit-children/