### PR TITLE
Fix create react app builds with es2015 target

### DIFF
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2015",
     "jsx": "react",
     "moduleResolution": "node",
     "module": "ES2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2015",
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
This fixes #1871 by setting the `target` to `es2015`

Tested using the following steps:
1. Edited target to `es2015`
1. Ran `yarn build`
1. Verified that optional chaining code in use-control.js was tranformed:

```js
        if (!map.hasControl(ctrl)) {
            map.addControl(ctrl, (_a = (opts || onRemove)) === null || _a === void 0 ? void 0 : _a.position);
        }
```
4. Copied dist folder to https://github.com/reesscot/react-mapbox-gl-test project's `node_modules` folder.
5. Noted that error message around optional chaining in `use-control.js` went away and got successful build:

![image](https://user-images.githubusercontent.com/6165315/169921962-5c043177-2b94-4262-b97a-b79e92598ae6.png)

