### PR TITLE
Add callback to useControl hook

### DIFF
--- a/docs/api-reference/use-control.md
+++ b/docs/api-reference/use-control.md
@@ -56,6 +56,15 @@ useControl<T extends IControl>(
     position?: ControlPosition;
   }
 ): T
+
+useControl<T extends IControl>(
+  onCreate: ({map: MapRef, mapLib: mapboxgl}) => IControl,
+  onAdd: ({map: MapRef, mapLib: mapboxgl}) => void,
+  onRemove: ({map: MapRef, mapLib: mapboxgl}) => void,
+  options?: {
+    position?: ControlPosition;
+  }
+): T
 ```
 
 The hook creates an [IControl](https://docs.mapbox.com/mapbox-gl-js/api/markers/#icontrol) instance, adds it to the map when it's available, and removes it upon unmount.
@@ -63,7 +72,8 @@ The hook creates an [IControl](https://docs.mapbox.com/mapbox-gl-js/api/markers/
 Parameters:
 
 - `onCreate`: ({map: MapRef, mapLib: mapboxgl}) => [IControl](/docs/api-reference/types.md#icontrol) - called to create an instance of the control.
-- `onRemove`: ({map: MapRef, mapLib: mapboxgl}) => void - called when the control is about to be removed.
+- `onAdd`: ({map: MapRef, mapLib: mapboxgl}) => void - called when the control has been added to the map.
+- `onRemove`: ({map: MapRef, mapLib: mapboxgl}) => void - called when the control is about to be removed from the map.
 - `options`: object
   + `position`: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' - control position relative to the map
 

--- a/examples/draw-polygon/src/draw-control.ts
+++ b/examples/draw-polygon/src/draw-control.ts
@@ -13,11 +13,11 @@ type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
 
 export default function DrawControl(props: DrawControlProps) {
   useControl<MapboxDraw>(
+    () => new MapboxDraw(props),
     ({map}: {map: MapRef}) => {
       map.on('draw.create', props.onCreate);
       map.on('draw.update', props.onUpdate);
       map.on('draw.delete', props.onDelete);
-      return new MapboxDraw(props);
     },
     ({map}: {map: MapRef}) => {
       map.off('draw.create', props.onCreate);

--- a/src/components/use-control.ts
+++ b/src/components/use-control.ts
@@ -7,22 +7,48 @@ type ControlOptions = {
   position?: ControlPosition;
 };
 
-export default function useControl<T extends IControl>(
+function useControl<T extends IControl>(
   onCreate: (context: MapContextValue) => T,
-  onRemove?: ((context: MapContextValue) => void) | ControlOptions,
   opts?: ControlOptions
+);
+
+function useControl<T extends IControl>(
+  onCreate: (context: MapContextValue) => T,
+  onRemove: (context: MapContextValue) => void,
+  opts?: ControlOptions
+);
+
+function useControl<T extends IControl>(
+  onCreate: (context: MapContextValue) => T,
+  onAdd: (context: MapContextValue) => void,
+  onRemove: (context: MapContextValue) => void,
+  opts?: ControlOptions
+);
+
+function useControl<T extends IControl>(
+  onCreate: (context: MapContextValue) => T,
+  arg1?: ((context: MapContextValue) => void) | ControlOptions,
+  arg2?: ((context: MapContextValue) => void) | ControlOptions,
+  arg3?: ControlOptions
 ) {
   const context = useContext(MapContext);
   const ctrl = useMemo(() => onCreate(context), []);
 
   useEffect(() => {
+    const opts = (arg3 || arg2 || arg1) as ControlOptions;
+    const onAdd = typeof arg1 === 'function' && typeof arg2 === 'function' ? arg1 : null;
+    const onRemove = typeof arg2 === 'function' ? arg2 : typeof arg1 === 'function' ? arg1 : null;
+
     const {map} = context;
     if (!map.hasControl(ctrl)) {
-      map.addControl(ctrl, (opts || (onRemove as ControlOptions))?.position);
+      map.addControl(ctrl, opts?.position);
+      if (onAdd) {
+        onAdd(context);
+      }
     }
 
     return () => {
-      if (typeof onRemove === 'function') {
+      if (onRemove) {
         onRemove(context);
       }
       // Map might have been removed (parent effects are destroyed before child ones)
@@ -34,3 +60,5 @@ export default function useControl<T extends IControl>(
 
   return ctrl;
 }
+
+export default useControl;


### PR DESCRIPTION
For https://github.com/visgl/react-map-gl/discussions/1949

The issue is that the way the `useControl` hook calls `onCreate` and `onRemove` is not symmetrical. Under `<StrictMode>`, `useEffect` is triggered twice, but `useMemo` is only triggered once. The current DrawControl example adds listeners in `onCreate` (`useMemo`), and removes listeners in `onRemove` (`useEffect`).

This PR adds a non-breaking new signature to `useControl` to provide symmetrical add/remove callbacks.