### PR TITLE
examples/draw-polygon GeoJSON.Feature type definition

### DIFF
--- a/examples/draw-polygon/src/app.tsx
+++ b/examples/draw-polygon/src/app.tsx
@@ -5,13 +5,14 @@ import Map from 'react-map-gl';
 
 import DrawControl from './draw-control';
 import ControlPanel from './control-panel';
+import GeoJSON from "geojson";
 
 const TOKEN = ''; // Set your mapbox token here
 
 export default function App() {
   const [features, setFeatures] = useState({});
 
-  const onUpdate = useCallback(e => {
+  const onUpdate = useCallback((e: { features: GeoJSON.Feature[] }) => {
     setFeatures(currFeatures => {
       const newFeatures = {...currFeatures};
       for (const f of e.features) {
@@ -21,7 +22,7 @@ export default function App() {
     });
   }, []);
 
-  const onDelete = useCallback(e => {
+  const onDelete = useCallback((e: { features: GeoJSON.Feature[] }) => {
     setFeatures(currFeatures => {
       const newFeatures = {...currFeatures};
       for (const f of e.features) {

--- a/examples/draw-polygon/src/draw-control.ts
+++ b/examples/draw-polygon/src/draw-control.ts
@@ -2,13 +2,14 @@ import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import {useControl} from 'react-map-gl';
 
 import type {MapRef, ControlPosition} from 'react-map-gl';
+import GeoJSON from "geojson";
 
 type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
   position?: ControlPosition;
 
-  onCreate?: (evt: {features: object[]}) => void;
-  onUpdate?: (evt: {features: object[]; action: string}) => void;
-  onDelete?: (evt: {features: object[]}) => void;
+  onCreate?: (evt: {features: GeoJSON.Feature[]}) => void;
+  onUpdate?: (evt: {features: GeoJSON.Feature[]; action: string}) => void;
+  onDelete?: (evt: {features: GeoJSON.Feature[]}) => void;
 };
 
 export default function DrawControl(props: DrawControlProps) {


### PR DESCRIPTION
Hi, thanks for providing this awesome component.
 
I am using a modified form of the **draw-polygon** example for a project and thought that using the GeoJSON.Feature type for the definition simplifies the access to e.g. the coordinates of the shapes (e.g. for an GeoJSON export function), which is why I want to share this small modification here. 