### PR TITLE
Add conditional to mapboxScaleControl._onMove

### DIFF
--- a/src/components/scale-control.js
+++ b/src/components/scale-control.js
@@ -51,7 +51,7 @@ function ScaleControl(props) {
 
   if (mapboxScaleControl) {
     mapboxScaleControl.options = props;
-    mapboxScaleControl._onMove();
+    if(mapboxScaleControl._onMove) mapboxScaleControl._onMove();
   }
 
   const style = useMemo(() => ({position: 'absolute', ...props.style}), [props.style]);


### PR DESCRIPTION
Fix map crashing if the scalecontrol object doesn't have the ._onMove property at any point in time.