### PR TITLE
Initialize useRef with default for use with existing Layer

### DIFF
--- a/src/components/layer.ts
+++ b/src/components/layer.ts
@@ -79,7 +79,7 @@ let layerCounter = 0;
 
 function Layer(props: LayerProps) {
   const map: MapboxMap = useContext(MapContext).map.getMap();
-  const propsRef = useRef(props);
+  const propsRef = useRef({id: props.id, type: props.type} as LayerProps);
   const [, setStyleLoaded] = useState(0);
 
   const id = useMemo(() => props.id || `jsx-layer-${layerCounter++}`, []);


### PR DESCRIPTION
It would be nice to be able to use `Layer` components to override "imported" Mapbox styles, such as `mapbox://styles/mapbox/outdoors-v11`.

For example, the component below loads the default `outdoors-v11` theme, which has a `contour-line` layer set to black. I attempt to change it to white:
```jsx
      <Map
        mapStyle="mapbox://styles/mapbox/outdoors-v11"
        mapboxAccessToken={config.mapboxAccessToken}
      >     
         <Layer
            id="contour-line"
            type="line"
            paint={{ "line-color": "#ffffff" }}
         />
      </Map>
```

But it won't work.  Currently, a `<Layer/>` won't override a layer `id` that already exists at initialization time.

`Layer` passes `props` and `prevProps`  to `updateLayer` so they can be diff-ed and the changes can be applied... but the problem in my case is that `props` and `prevProps` will have the same value at initialization time. This is because `Layer` assumes that it will call `createLayer` on its first render, and immediately initializes `propsRef` to `props`.

By initializing to `propsRef` to an "empty" `LayerProps` value,  I'm adding the ability for `updateLayer` to correctly diff the initial `props` and apply them to the map layer. I don't believe this will change any other behavior, as `propsRef.current = props` is correctly set at the bottom of the function anyways.

I hope this is useful! It certainly has been for me, this has proven to be a very nice way for me to mostly rely on Mapbox's default styles, but override just a few things.