### PR TITLE
Fix SymbolLayer crash on style update

### DIFF
--- a/src/components/source.ts
+++ b/src/components/source.ts
@@ -94,7 +94,7 @@ function Source(props: SourceProps) {
 
   useEffect(() => {
     if (map) {
-      const forceUpdate = () => setStyleLoaded(version => version + 1);
+      const forceUpdate = () => setTimeout(() => setStyleLoaded(version => version + 1), 0);
       map.on('styledata', forceUpdate);
       forceUpdate();
 


### PR DESCRIPTION
Symbol layer crashed when style are updated with the error `Cannot read properties of undefined (reading 'get')`  (see  #1844)

This PR handles the condition when the `Source` is updated while the style is loading, by using a `setTimeout(...,0)`. 

As describe [here](https://github.com/maplibre/maplibre-gl-js/issues/1835#issuecomment-1310741571), an other solution is to listen on `style.load` instead of `styledata`, but it's a private event...

So IMHO, the `setTimeout` is better.