### PR TITLE
Added the globe projection type, which was introduced in Mapbox GL JS v2.9

### DIFF
--- a/docs/api-reference/map.md
+++ b/docs/api-reference/map.md
@@ -92,7 +92,7 @@ The map's Mapbox style. This must be an a JSON object conforming to the schema d
 
 Default: `'mercator'`
 
-The projection the map should be rendered in. Available projections are Albers (`'albers'`), Equal Earth (`'equalEarth'`), Equirectangular/Plate Carrée/WGS84 (`'equirectangular'`), Lambert (`'lambertConformalConic'`), Mercator (`'mercator'`), Natural Earth (`'naturalEarth'`), and Winkel Tripel (`'winkelTripel'`). Conic projections such as Albers and Lambert have configurable `center` and `parallels` properties that allow developers to define the region in which the projection has minimal distortion; see [example](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setprojection).
+The projection the map should be rendered in. Available projections are Albers (`'albers'`), Equal Earth (`'equalEarth'`), Equirectangular/Plate Carrée/WGS84 (`'equirectangular'`), Globe (`'globe'`), Lambert (`'lambertConformalConic'`), Mercator (`'mercator'`), Natural Earth (`'naturalEarth'`), and Winkel Tripel (`'winkelTripel'`). Conic projections such as Albers and Lambert have configurable `center` and `parallels` properties that allow developers to define the region in which the projection has minimal distortion; see [example](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setprojection).
 
 #### `renderWorldCopies`: boolean
 

--- a/docs/api-reference/types.md
+++ b/docs/api-reference/types.md
@@ -47,7 +47,7 @@ An object conforming to the [Terrain Style Specification](https://docs.mapbox.co
 
 An object with the following fields:
 
-- `name` (string): projection name, one of Albers (`'albers'`), Equal Earth (`'equalEarth'`), Equirectangular/Plate Carrée/WGS84 (`'equirectangular'`), Lambert (`'lambertConformalConic'`), Mercator (`'mercator'`), Natural Earth (`'naturalEarth'`), and Winkel Tripel (`'winkelTripel'`).
+- `name` (string): projection name, one of Albers (`'albers'`), Equal Earth (`'equalEarth'`), Equirectangular/Plate Carrée/WGS84 (`'equirectangular'`), Globe (`'globe'`), Lambert (`'lambertConformalConic'`), Mercator (`'mercator'`), Natural Earth (`'naturalEarth'`), and Winkel Tripel (`'winkelTripel'`).
 - `center?` ([number, number]): longitude and latitude of the projection center
 - `parallels?` ([number, number]): the [two standard parallels](https://en.wikipedia.org/wiki/Map_projection#Conic) of a conic projection such as Albers and Lambert.
 

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -6,6 +6,7 @@ export type ProjectionSpecification = {
     | 'albers'
     | 'equalEarth'
     | 'equirectangular'
+    | 'globe'
     | 'lambertConformalConic'
     | 'mercator'
     | 'naturalEarth'


### PR DESCRIPTION
The Globe projection type is currently the default projection type in Mapbox, and was introduced in v2.9.
See: https://www.mapbox.com/blog/globe-view
I just thought it would be good to add explicit support for the projection type.