### PR TITLE
Use correct version for mapbox-gl

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/mapbox-gl": "^2.6.0"
   },
   "peerDependencies": {
-    "mapbox-gl": "*",
+    "mapbox-gl": ">=1.13.0",
     "react": ">=16.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi
This PR is for changing the version of `mapbox-gl` from `*` to `<= 1.13.0`.
In detail, map.hasControl, api which is used on useControl, was added since v1.13.0 and type error is thrown if useControl and any control components are used with mapbox-gl v1.12.0 and below.

v1.12.0: https://github.com/mapbox/mapbox-gl-js/blob/v1.12.0/src/ui/map.js
v1.13.0: https://github.com/mapbox/mapbox-gl-js/blob/v1.13.0/src/ui/map.js
