### PR TITLE
Fix crash in React 18 StrictMode (#1680)

### DIFF
--- a/src/mapbox/mapbox.js
+++ b/src/mapbox/mapbox.js
@@ -365,15 +365,23 @@ export default class Mapbox {
     /* eslint-disable accessor-pairs */
     const {container} = props;
     // $FlowFixMe
-    Object.defineProperty(container, 'offsetWidth', {get: () => this.width});
+    Object.defineProperty(container, 'offsetWidth', {
+      configurable: true,
+      get: () => this.width
+    });
     // $FlowFixMe
-    Object.defineProperty(container, 'clientWidth', {get: () => this.width});
+    Object.defineProperty(container, 'clientWidth', {
+      configurable: true,
+      get: () => this.width
+    });
     // $FlowFixMe
     Object.defineProperty(container, 'offsetHeight', {
+      configurable: true,
       get: () => this.height
     });
     // $FlowFixMe
     Object.defineProperty(container, 'clientHeight', {
+      configurable: true,
       get: () => this.height
     });
 


### PR DESCRIPTION
Since `v5.3.x` is not working well (https://github.com/visgl/react-map-gl/issues/2103), please accept the port of the fix for React 18 into the `v5.2.x` branch.