### PR TITLE
Docs: Add types to use control example

### DIFF
--- a/docs/api-reference/use-control.md
+++ b/docs/api-reference/use-control.md
@@ -6,6 +6,14 @@ The `useControl` hook is used to create React wrappers for custom map controls.
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import Map, {useControl} from 'react-map-gl';
 
+type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
+  position?: ControlPosition;
+
+  onCreate?: (evt: {features: object[]}) => void;
+  onUpdate?: (evt: {features: object[]; action: string}) => void;
+  onDelete?: (evt: {features: object[]}) => void;
+};
+
 function DrawControl(props: DrawControlProps) {
   useControl(() => new MapboxDraw(props), {
     position: props.position


### PR DESCRIPTION
The page https://github.com/visgl/react-map-gl/blob/master/docs/api-reference/use-control.md?plain=1#L9 / http://visgl.github.io/react-map-gl/docs/api-reference/use-control uses the Types `DrawControlProps` which are not specified in the example / on the page.

They are specified on this page https://github.com/visgl/react-map-gl/blob/master/examples/draw-polygon/src/draw-control.ts#L6-L12 , however.

This PR add them to the example.
