### PR TITLE
Update how defaultprops are handled on functional components

### DIFF
--- a/examples/draw-polygon/src/draw-control.ts
+++ b/examples/draw-polygon/src/draw-control.ts
@@ -2,6 +2,7 @@ import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import {useControl} from 'react-map-gl';
 
 import type {MapRef, ControlPosition} from 'react-map-gl';
+import {useMemo} from 'react';
 
 type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
   position?: ControlPosition;
@@ -11,7 +12,12 @@ type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
   onDelete?: (evt: {features: object[]}) => void;
 };
 
-export default function DrawControl(props: DrawControlProps) {
+export default function DrawControl(componentProps: DrawControlProps) {
+  const props: DrawControlProps = useMemo(
+    () => ({onCreate: () => {}, onUpdate: () => {}, onDelete: () => {}, ...componentProps}),
+    [componentProps]
+  );
+
   useControl<MapboxDraw>(
     () => new MapboxDraw(props),
     ({map}: {map: MapRef}) => {
@@ -31,9 +37,3 @@ export default function DrawControl(props: DrawControlProps) {
 
   return null;
 }
-
-DrawControl.defaultProps = {
-  onCreate: () => {},
-  onUpdate: () => {},
-  onDelete: () => {}
-};

--- a/examples/geocoder/src/geocoder-control.tsx
+++ b/examples/geocoder/src/geocoder-control.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import {useControl, Marker, MarkerProps, ControlPosition} from 'react-map-gl';
 import MapboxGeocoder, {GeocoderOptions} from '@mapbox/mapbox-gl-geocoder';
 
@@ -16,7 +16,18 @@ type GeocoderControlProps = Omit<GeocoderOptions, 'accessToken' | 'mapboxgl' | '
 };
 
 /* eslint-disable complexity,max-statements */
-export default function GeocoderControl(props: GeocoderControlProps) {
+export default function GeocoderControl(componentProps: GeocoderControlProps) {
+  const props: GeocoderControlProps = useMemo(
+    () => ({
+      marker: true,
+      onLoading: noop,
+      onResults: noop,
+      onResult: noop,
+      onError: noop,
+      ...componentProps
+    }),
+    [componentProps]
+  );
   const [marker, setMarker] = useState(null);
 
   const geocoder = useControl<MapboxGeocoder>(
@@ -105,11 +116,3 @@ export default function GeocoderControl(props: GeocoderControlProps) {
 }
 
 const noop = () => {};
-
-GeocoderControl.defaultProps = {
-  marker: true,
-  onLoading: noop,
-  onResults: noop,
-  onResult: noop,
-  onError: noop
-};

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -66,7 +66,9 @@ const defaultProps: MapProps = {
     'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js'
 };
 
-const Map = forwardRef<MapRef, MapProps>((props, ref) => {
+const Map = forwardRef<MapRef, MapProps>((componentProps, ref) => {
+  const props: MapProps = useMemo(() => ({...defaultProps, ...componentProps}), [componentProps]);
+
   const mountedMapsContext = useContext(MountedMapsContext);
   const [mapInstance, setMapInstance] = useState<Mapbox>(null);
   const containerRef = useRef();
@@ -161,6 +163,5 @@ const Map = forwardRef<MapRef, MapProps>((props, ref) => {
 });
 
 Map.displayName = 'Map';
-Map.defaultProps = defaultProps;
 
 export default Map;

--- a/src/components/marker.ts
+++ b/src/components/marker.ts
@@ -83,7 +83,12 @@ const defaultProps: Partial<MarkerProps> = {
 };
 
 /* eslint-disable complexity,max-statements */
-function Marker(props: MarkerProps) {
+function Marker(componentProps: MarkerProps) {
+  const props: MarkerProps = useMemo(
+    () => ({...defaultProps, ...componentProps}),
+    [componentProps]
+  );
+
   const {map, mapLib} = useContext(MapContext);
   const thisRef = useRef({props});
   thisRef.current.props = props;
@@ -165,8 +170,6 @@ function Marker(props: MarkerProps) {
 
   return createPortal(props.children, marker.getElement());
 }
-
-Marker.defaultProps = defaultProps;
 
 // @ts-ignore
 export default React.memo(Marker);

--- a/src/components/scale-control.ts
+++ b/src/components/scale-control.ts
@@ -25,7 +25,12 @@ const defaultProps: ScaleControlProps = {
   maxWidth: 100
 };
 
-function ScaleControl(props: ScaleControlProps): null {
+function ScaleControl(componentProps: ScaleControlProps): null {
+  const props: ScaleControlProps = React.useMemo(
+    () => ({...defaultProps, ...componentProps}),
+    [componentProps]
+  );
+
   const ctrl = useControl<MapboxScaleControl>(({mapLib}) => new mapLib.ScaleControl(props), {
     position: props.position
   });
@@ -45,7 +50,5 @@ function ScaleControl(props: ScaleControlProps): null {
 
   return null;
 }
-
-ScaleControl.defaultProps = defaultProps;
 
 export default React.memo(ScaleControl);


### PR DESCRIPTION
As per issue #2117, this PR removes the usage of defaultProps and move it to inside the functional component by merging the default parameters with the component props and using useMemo in order to avoid unnecessary recalculation.