### PR TITLE
Inherit parent height in`mapboxgl-children` div

### DIFF
--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -153,7 +153,7 @@ const Map = forwardRef<MapRef, MapProps>((props, ref) => {
     <div id={props.id} ref={containerRef} style={style}>
       {mapInstance && (
         <MapContext.Provider value={contextValue}>
-          <div mapboxgl-children="">{props.children}</div>
+          <div mapboxgl-children="" style={{ height: 'inherit' }}>{props.children}</div>
         </MapContext.Provider>
       )}
     </div>


### PR DESCRIPTION
The new 'mapboxgl-children' div brakes styling for those who depend on the default height of 100% of the parent div. Adding `height: inherit` to the new div solves the issue.