### PR TITLE
Change return type of `useControl` to return `T` instead of `any`

### DIFF
--- a/src/components/use-control.ts
+++ b/src/components/use-control.ts
@@ -10,27 +10,27 @@ type ControlOptions = {
 function useControl<T extends IControl>(
   onCreate: (context: MapContextValue) => T,
   opts?: ControlOptions
-);
+): T;
 
 function useControl<T extends IControl>(
   onCreate: (context: MapContextValue) => T,
   onRemove: (context: MapContextValue) => void,
   opts?: ControlOptions
-);
+): T;
 
 function useControl<T extends IControl>(
   onCreate: (context: MapContextValue) => T,
   onAdd: (context: MapContextValue) => void,
   onRemove: (context: MapContextValue) => void,
   opts?: ControlOptions
-);
+): T;
 
 function useControl<T extends IControl>(
   onCreate: (context: MapContextValue) => T,
   arg1?: ((context: MapContextValue) => void) | ControlOptions,
   arg2?: ((context: MapContextValue) => void) | ControlOptions,
   arg3?: ControlOptions
-) {
+): T {
   const context = useContext(MapContext);
   const ctrl = useMemo(() => onCreate(context), []);
 


### PR DESCRIPTION
When the useControl file is compiled to the d.ts file, its return value is lost.

In the [original markdown](https://github.com/visgl/react-map-gl/pull/1952/files) the return type did include `T`, so we just re-add it here.