### PR TITLE
fix: add missing field performanceMetricsCollection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log
 .reify-cache
 
 .idea
+.npmrc

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-map-gl",
-  "description": "React components for Mapbox GL JS-compatible libraries",
-  "version": "7.0.0",
+  "name": "@s19/react-map-gl",
+  "description": "Fork of react components for Mapbox GL JS-compatible libraries",
+  "version": "7.0.1",
   "keywords": [
     "mapbox",
     "mapbox-gl",

--- a/src/mapbox/mapbox.ts
+++ b/src/mapbox/mapbox.ts
@@ -145,6 +145,11 @@ export type MapboxProps = Partial<ViewState> & {
    */
   maxTileCacheSize?: number;
   /**
+   * If true , mapbox-gl will collect and send performance metrics.
+   * defaults to true
+   */
+  performanceMetricsCollection?: boolean;
+  /**
    * If true, map will prioritize rendering for performance by reordering layers
    * If false, layers will always be drawn in the specified order
    * @default true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3386,9 +3386,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001286:
-  version "1.0.30001312"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz"
-  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
+  version "1.0.30001469"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz"
+  integrity sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Hello there!

I am working on a project that requires cookie consent policy. I notice that using mapbox, it will always trigger the performance cookies. For mapbox@2 it has a field that could disable the metric collection. Please let me know if I need more work for adding `performanceMetricsCollection` field


https://docs.mapbox.com/mapbox-gl-js/api/map/
https://www.mapbox.com/legal/cookies

A bunch of performance cookies trigger by mapbox
<img width="774" alt="image" src="https://user-images.githubusercontent.com/102495463/227231030-09b9c649-6d99-44f5-9bdf-f2bcd0c83850.png">
