### PR TITLE
Force map reload upon reuse

### DIFF
--- a/src/mapbox/mapbox.ts
+++ b/src/mapbox/mapbox.ts
@@ -506,8 +506,9 @@ export default class Mapbox {
       map.once('styledata', () => map.fire('load'));
     }
 
-    // Force redraw
-    map.triggerRepaint();
+    // Force reload
+    // @ts-ignore
+    map._update();
     return that;
   }
 


### PR DESCRIPTION
Another attempt to resolve #2154

`map_update()` is called internally upon move event to reload sources and rerender.