### PR TITLE
Fix maplibre-gl peerDependencies typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "mapbox-gl": ">=1.13.0",
-    "maplibregl": ">=1.13.0",
+    "maplibre-gl": ">=1.13.0",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0"
   },


### PR DESCRIPTION
Would love to test `7.1.0-beta.1`, but it's currently not possible using `npm` due to a typo in the `peerDependencies`.

```
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-map-gl@7.1.0-beta.1
npm WARN Found: maplibregl@undefined
npm WARN node_modules/maplibregl
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer maplibregl@">=1.13.0" from react-map-gl@7.1.0-beta.1
npm WARN node_modules/react-map-gl
npm WARN   react-map-gl@"7.1.0-beta.1" from the root project
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/maplibregl - Not found
npm ERR! 404 
npm ERR! 404  'maplibregl@>=1.13.0' is not in this registry.
```
