### PR TITLE
Remap event types

### DIFF
--- a/src/exports-mapbox.ts
+++ b/src/exports-mapbox.ts
@@ -38,6 +38,7 @@ import {
 } from './components/scale-control';
 import {useMap as _useMap} from './components/use-map';
 import type {MapRef as _MapRef} from './mapbox/create-ref';
+import type * as events from './types/events';
 
 export function useMap() {
   return _useMap<MapboxMap>();
@@ -106,3 +107,22 @@ export default Map;
 export * from './types/public';
 export type {SourceProps} from './components/source';
 export type {LayerProps} from './components/layer';
+
+// Events
+export type MapEvent = events.MapEvent<MapboxMap>;
+export type ErrorEvent = events.ErrorEvent<MapboxMap>;
+export type MapStyleDataEvent = events.MapStyleDataEvent<MapboxMap>;
+export type MapSourceDataEvent = events.MapSourceDataEvent<MapboxMap>;
+export type MapMouseEvent = events.MapMouseEvent<MapboxMap>;
+export type MapLayerMouseEvent = events.MapLayerMouseEvent<MapboxMap>;
+export type MapTouchEvent = events.MapTouchEvent<MapboxMap>;
+export type MapLayerTouchEvent = events.MapLayerTouchEvent<MapboxMap>;
+export type MapWheelEvent = events.MapWheelEvent<MapboxMap>;
+export type MapBoxZoomEvent = events.MapBoxZoomEvent<MapboxMap>;
+export type ViewStateChangeEvent = events.ViewStateChangeEvent<MapboxMap>;
+export type PopupEvent = events.PopupEvent<MapboxPopup>;
+export type MarkerEvent = events.MarkerEvent<MapboxMarker>;
+export type MarkerDragEvent = events.MarkerDragEvent<MapboxMarker>;
+export type GeolocateEvent = events.GeolocateEvent<MapboxGeolocateControl>;
+export type GeolocateResultEvent = events.GeolocateResultEvent<MapboxGeolocateControl>;
+export type GeolocateErrorEvent = events.GeolocateErrorEvent<MapboxGeolocateControl>;

--- a/src/exports-maplibre.ts
+++ b/src/exports-maplibre.ts
@@ -38,6 +38,7 @@ import {
 } from './components/scale-control';
 import {useMap as _useMap} from './components/use-map';
 import type {MapRef as _MapRef} from './mapbox/create-ref';
+import type * as events from './types/events';
 
 export function useMap() {
   return _useMap<MaplibreMap>();
@@ -106,3 +107,22 @@ export default Map;
 export * from './types/public';
 export type {SourceProps} from './components/source';
 export type {LayerProps} from './components/layer';
+
+// Events
+export type MapEvent = events.MapEvent<MaplibreMap>;
+export type ErrorEvent = events.ErrorEvent<MaplibreMap>;
+export type MapStyleDataEvent = events.MapStyleDataEvent<MaplibreMap>;
+export type MapSourceDataEvent = events.MapSourceDataEvent<MaplibreMap>;
+export type MapMouseEvent = events.MapMouseEvent<MaplibreMap>;
+export type MapLayerMouseEvent = events.MapLayerMouseEvent<MaplibreMap>;
+export type MapTouchEvent = events.MapTouchEvent<MaplibreMap>;
+export type MapLayerTouchEvent = events.MapLayerTouchEvent<MaplibreMap>;
+export type MapWheelEvent = events.MapWheelEvent<MaplibreMap>;
+export type MapBoxZoomEvent = events.MapBoxZoomEvent<MaplibreMap>;
+export type ViewStateChangeEvent = events.ViewStateChangeEvent<MaplibreMap>;
+export type PopupEvent = events.PopupEvent<MaplibrePopup>;
+export type MarkerEvent = events.MarkerEvent<MaplibreMarker>;
+export type MarkerDragEvent = events.MarkerDragEvent<MaplibreMarker>;
+export type GeolocateEvent = events.GeolocateEvent<MaplibreGeolocateControl>;
+export type GeolocateResultEvent = events.GeolocateResultEvent<MaplibreGeolocateControl>;
+export type GeolocateErrorEvent = events.GeolocateErrorEvent<MaplibreGeolocateControl>;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,5 @@
-export type {IControl} from './lib';
+import type GeoJSON from 'geojson';
+import type {AnyLayer} from './style-spec';
 
 /* Data types */
 export interface Point {
@@ -81,3 +82,10 @@ export type ControlPosition = 'top-right' | 'top-left' | 'bottom-right' | 'botto
 export interface ImmutableLike<T> {
   toJS: () => T;
 }
+
+export type MapGeoJSONFeature = GeoJSON.Feature<GeoJSON.Geometry> & {
+  layer: AnyLayer;
+  source: string;
+  sourceLayer: string;
+  state: {[key: string]: any};
+};

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,5 +1,4 @@
-import type GeoJSON from 'geojson';
-import type {ViewState, Point, LngLat, LngLatBounds} from './common';
+import type {ViewState, Point, LngLat, LngLatBounds, MapGeoJSONFeature} from './common';
 import type {
   MapInstance,
   Evented,
@@ -7,14 +6,7 @@ import type {
   PopupInstance,
   GeolocateControlInstance
 } from './lib';
-import type {AnyLayer, AnySource} from './style-spec';
-
-export type MapGeoJSONFeature = GeoJSON.Feature<GeoJSON.Geometry> & {
-  layer: AnyLayer;
-  source: string;
-  sourceLayer: string;
-  state: {[key: string]: any};
-};
+import type {AnySource} from './style-spec';
 
 export interface MapEvent<SourceT extends Evented, OriginalEventT = undefined> {
   type: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './public';
+export * from './events';
 
 import type GeoJSON from 'geojson';
 import type {CustomSourceImplementation} from './lib';

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -1,4 +1,3 @@
 export * from './common';
-export * from './events';
 export * from './style-spec';
 export * from './lib';


### PR DESCRIPTION
The event types are defined as generics. Remap them with the corresponding types for mapbox/maplibre endpoints