### PR TITLE
Add className prop support to Marker

### DIFF
--- a/docs/api-reference/marker.md
+++ b/docs/api-reference/marker.md
@@ -77,6 +77,10 @@ Required. The latitude of the anchor location.
 
 Required. The longitude of the anchor location.
 
+#### `className`: string {#classname}
+
+Space-separated CSS class names to add to popup container.
+
 #### `offset`: [PointLike](./types.md#pointlike) {#offset}
 
 Default: `null`

--- a/test/src/components/marker.spec.jsx
+++ b/test/src/components/marker.spec.jsx
@@ -91,6 +91,18 @@ test('Marker', async t => {
 
   t.ok(map.root.findByProps({id: 'marker-content'}), 'content is rendered');
 
+  act(() => {
+    map.update(
+      <Map ref={mapRef} mapLib={mapboxMock}>
+        <Marker longitude={-100} latitude={40} className="classA">
+          <div id="marker-content" />
+        </Marker>
+      </Map>
+    );
+  });
+
+  t.ok(map.root.findByProps({className: 'classA'}), 'className is updated');
+
   map.unmount();
 
   restoreMock();


### PR DESCRIPTION
When having multiple types of markers on the map that have hierarchy rules to them which requires setting different `z-index` being able to pass a different `className` to the Marker component is necessary.

```css
.secondary {
  z-index: 1;
}

.primary {
  z-index: 2;
}
```

```jsx
<Map>
  <Marker className="secondary">Secondary</Marker>
  <Marker className="primary">Primary</Marker>
</Map>
```

Considering on making a PR to `mapbox-gl` as well to update the Marker to have similar className option like the Popup component, but it felt it might be easier to get this update into react-map-gl first.
Edit: Stared a PR https://github.com/mapbox/mapbox-gl-js/pull/12770 - will see what mapbox team say...
Edit2:  Started a PR https://github.com/maplibre/maplibre-gl-js/pull/2729 for `maplibre-gl-js` for consistency between libs