### PR TITLE
Modify peer dependency to avoid a 7.x breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/mapbox-gl": ">=1.0.0"
   },
   "peerDependencies": {
-    "mapbox-gl": ">=1.13.0",
+    "mapbox-gl": ">=1.0.0",
     "maplibre-gl": ">=1.13.0",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0"


### PR DESCRIPTION
Previously, the 7.0 documentation suggested mapping "empty-npm-package@^1.0.0" to mapbox-gl when using react-map-gl with maplibre. In order to avoid a breaking change, this reverts the mapbox-gl peer dependency from ">=1.13.0" to ">=1.0.0" so that users who followed this advice can safely upgrade within the 7.x series, complying with semantic versioning. Fixes #2230.