### PR TITLE
Docusaurus: Fix `editUrl`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -28,7 +28,7 @@ const config = {
           path: '../docs',
           sidebarPath: resolve('./src/docs-sidebar.js'),
           // Point to to the website directory in your repo.
-          editUrl: 'https://github.com/visgl/deck.gl/tree/master/website'
+          editUrl: 'https://github.com/visgl/react-map-gl/tree/master/docs'
         },
         theme: {
           customCss: [


### PR DESCRIPTION
This was still pointing to deck.gl, so the edit links on for example https://visgl.github.io/react-map-gl/docs/get-started did not work

`https://github.com/visgl/deck.gl/tree/master/docs/get-started/get-started.md`

I did not test this new URL, but I think it should work …