### PR TITLE
Docs/upgrade-guide: Underline the updated import in example

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -18,7 +18,7 @@ function App() {
 ```
 
 ```tsx title="map-v7.1.tsx"
-import Map from 'react-map-gl/maplibre';
+import Map from 'react-map-gl/maplibre'; // <- mind the updated import
 
 function App() {
   return <Map


### PR DESCRIPTION
I read the docs again and again but it still did not register that I have to update the import…
Maybe this hint will help the next person.