### PR TITLE
Fix typechecking (#1798)

### DIFF
--- a/src/components/use-map.tsx
+++ b/src/components/use-map.tsx
@@ -52,7 +52,10 @@ export const MapProvider: React.FC<{children?: React.ReactNode}> = props => {
   );
 };
 
-export function useMap<MapT extends MapInstance>() {
+export function useMap<MapT extends MapInstance>(): {
+  [id: string]: MapRef<MapT> | undefined;
+  current?: MapRef<MapT>;
+} {
   const maps = useContext(MountedMapsContext)?.maps;
   const currentMap = useContext(MapContext);
 


### PR DESCRIPTION
Fixes a resurgence of the bug found in #1798

It might be a breaking change because it forces code like this:

```ts
  const draw = useControl<MapboxGlDraw>(
    () => new MapboxGlDraw(rest),
    ({ map }: MapContextValue<MapInstance>) => {
      map.on("draw.create", onCreate);
    },
    ({ map }: MapContextValue<MapInstance>) => {
      map.off("draw.create", onCreate);
    },
    {
      position,
    },
  );
```

to become:

```ts
  const draw = useControl<MapboxGlDraw>(
    () => new MapboxGlDraw(rest),
    ({ map }: MapContextValue<MapInstance>) => {
      map?.on("draw.create", onCreate);
    },
    ({ map }: MapContextValue<MapInstance>) => {
      map?.off("draw.create", onCreate);
    },
    {
      position,
    },
  );
```
