### PR TITLE
Import style and event types from specific base libraries

### DIFF
--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -8,7 +8,7 @@ import createRef, {MapRef} from '../mapbox/create-ref';
 import type {CSSProperties} from 'react';
 import useIsomorphicLayoutEffect from '../utils/use-isomorphic-layout-effect';
 import setGlobals, {GlobalSettings} from '../utils/set-globals';
-import type {MapLib, MapInstance} from '../types';
+import type {MapLib, MapInstance, MapStyle} from '../types';
 
 export type MapContextValue<MapT extends MapInstance = MapInstance> = {
   mapLib: MapLib<MapT>;
@@ -22,8 +22,12 @@ type MapInitOptions<MapOptions> = Omit<
   'style' | 'container' | 'bounds' | 'fitBoundsOptions' | 'center'
 >;
 
-export type MapProps<MapOptions, MapT extends MapInstance> = MapInitOptions<MapOptions> &
-  MapboxProps<MapT> &
+export type MapProps<
+  MapOptions,
+  StyleT extends MapStyle,
+  MapT extends MapInstance
+> = MapInitOptions<MapOptions> &
+  MapboxProps<StyleT, MapT> &
   GlobalSettings & {
     mapLib?: MapLib<MapT> | Promise<MapLib<MapT>>;
     reuseMaps?: boolean;
@@ -34,13 +38,13 @@ export type MapProps<MapOptions, MapT extends MapInstance> = MapInitOptions<MapO
     children?: any;
   };
 
-export default function Map<MapOptions, MapT extends MapInstance>(
-  props: MapProps<MapOptions, MapT>,
+export default function Map<MapOptions, StyleT extends MapStyle, MapT extends MapInstance>(
+  props: MapProps<MapOptions, StyleT, MapT>,
   ref: React.Ref<MapRef<MapT>>,
   defaultLib: MapLib<MapT> | Promise<MapLib<MapT>>
 ) {
   const mountedMapsContext = useContext(MountedMapsContext);
-  const [mapInstance, setMapInstance] = useState<Mapbox<MapT>>(null);
+  const [mapInstance, setMapInstance] = useState<Mapbox<StyleT, MapT>>(null);
   const containerRef = useRef();
 
   const {current: contextValue} = useRef<MapContextValue<MapT>>({mapLib: null, map: null});
@@ -48,7 +52,7 @@ export default function Map<MapOptions, MapT extends MapInstance>(
   useEffect(() => {
     const mapLib = props.mapLib;
     let isMounted = true;
-    let mapbox: Mapbox<MapT>;
+    let mapbox: Mapbox<StyleT, MapT>;
 
     Promise.resolve(mapLib || defaultLib)
       .then((module: MapLib<MapT> | {default: MapLib<MapT>}) => {

--- a/src/components/source.ts
+++ b/src/components/source.ts
@@ -65,7 +65,9 @@ function updateSource<SourceT extends ISource>(
   const type = props.type;
 
   if (type === 'geojson') {
-    (source as GeoJSONSourceImplementation).setData((props as unknown as GeoJSONSource).data as any);
+    (source as GeoJSONSourceImplementation).setData(
+      (props as unknown as GeoJSONSource).data as any
+    );
   } else if (type === 'image') {
     (source as ImageSourceImplemtation).updateImage({
       url: (props as unknown as ImageSource).url,

--- a/src/components/source.ts
+++ b/src/components/source.ts
@@ -7,24 +7,26 @@ import {deepEqual} from '../utils/deep-equal';
 
 import type {
   MapInstance,
-  AnySource,
+  ISource,
   CustomSource,
-  GeoJSONSource,
   GeoJSONSourceImplementation,
-  ImageSource,
   ImageSourceImplemtation,
-  VectorSource,
   AnySourceImplementation
 } from '../types';
+import type {GeoJSONSource, ImageSource, VectorSource} from '../types/style-spec-maplibre';
 
-export type SourceProps = (AnySource | CustomSource) & {
+export type SourceProps<SourceT> = (SourceT | CustomSource) & {
   id?: string;
   children?: any;
 };
 
 let sourceCounter = 0;
 
-function createSource(map: MapInstance, id: string, props: SourceProps) {
+function createSource<SourceT extends ISource>(
+  map: MapInstance,
+  id: string,
+  props: SourceProps<SourceT>
+) {
   // @ts-ignore
   if (map.style && map.style._loaded) {
     const options = {...props};
@@ -38,7 +40,11 @@ function createSource(map: MapInstance, id: string, props: SourceProps) {
 }
 
 /* eslint-disable complexity */
-function updateSource(source: AnySourceImplementation, props: SourceProps, prevProps: SourceProps) {
+function updateSource<SourceT extends ISource>(
+  source: AnySourceImplementation,
+  props: SourceProps<SourceT>,
+  prevProps: SourceProps<SourceT>
+) {
   assert(props.id === prevProps.id, 'source id changed');
   assert(props.type === prevProps.type, 'source type changed');
 
@@ -59,24 +65,24 @@ function updateSource(source: AnySourceImplementation, props: SourceProps, prevP
   const type = props.type;
 
   if (type === 'geojson') {
-    (source as GeoJSONSourceImplementation).setData((props as GeoJSONSource).data as any);
+    (source as GeoJSONSourceImplementation).setData((props as unknown as GeoJSONSource).data as any);
   } else if (type === 'image') {
     (source as ImageSourceImplemtation).updateImage({
-      url: props.url,
-      coordinates: props.coordinates
+      url: (props as unknown as ImageSource).url,
+      coordinates: (props as unknown as ImageSource).coordinates
     });
   } else if ('setCoordinates' in source && changedKeyCount === 1 && changedKey === 'coordinates') {
-    source.setCoordinates((props as unknown as ImageSource).coordinates);
+    source.setCoordinates((props as ImageSource).coordinates);
   } else if ('setUrl' in source) {
     // Added in 1.12.0:
     // vectorTileSource.setTiles
     // vectorTileSource.setUrl
     switch (changedKey) {
       case 'url':
-        source.setUrl((props as unknown as VectorSource).url);
+        source.setUrl((props as VectorSource).url);
         break;
       case 'tiles':
-        source.setTiles((props as unknown as VectorSource).tiles);
+        source.setTiles((props as VectorSource).tiles);
         break;
       default:
     }
@@ -87,7 +93,7 @@ function updateSource(source: AnySourceImplementation, props: SourceProps, prevP
 }
 /* eslint-enable complexity */
 
-function Source(props: SourceProps) {
+function Source<SourceT extends ISource>(props: SourceProps<SourceT>) {
   const map = useContext(MapContext).map.getMap();
   const propsRef = useRef(props);
   const [, setStyleLoaded] = useState(0);

--- a/src/exports-mapbox.ts
+++ b/src/exports-mapbox.ts
@@ -12,6 +12,7 @@ import type {
   NavigationControl as MapboxNavigationControl,
   ScaleControl as MapboxScaleControl
 } from 'mapbox-gl';
+import {MapboxStyle, AnyLayer, AnySource} from './types/style-spec-mapbox';
 
 import {default as _Map, MapProps as _MapProps} from './components/map';
 import {default as _Marker, MarkerProps as _MarkerProps} from './components/marker';
@@ -36,6 +37,8 @@ import {
   default as _ScaleControl,
   ScaleControlProps as _ScaleControlProps
 } from './components/scale-control';
+import {default as _Layer, LayerProps as _LayerProps} from './components/layer';
+import {default as _Source, SourceProps as _SourceProps} from './components/source';
 import {useMap as _useMap} from './components/use-map';
 import type {MapRef as _MapRef} from './mapbox/create-ref';
 import type * as events from './types/events';
@@ -44,7 +47,7 @@ export function useMap() {
   return _useMap<MapboxMap>();
 }
 
-export type MapProps = _MapProps<MapboxOptions, MapboxMap>;
+export type MapProps = _MapProps<MapboxOptions, MapboxStyle, MapboxMap>;
 export type MapRef = _MapRef<MapboxMap>;
 const mapLib = import('mapbox-gl');
 export const Map = (() => {
@@ -96,8 +99,12 @@ export const ScaleControl = _ScaleControl as (
   props: ScaleControlProps
 ) => React.ReactElement | null;
 
-export {default as Source} from './components/source';
-export {default as Layer} from './components/layer';
+export type LayerProps = _LayerProps<AnyLayer>;
+export const Layer = _Layer as (props: LayerProps) => React.ReactElement | null;
+
+export type SourceProps = _SourceProps<AnySource>;
+export const Source = _Source as (props: SourceProps) => React.ReactElement | null;
+
 export {default as useControl} from './components/use-control';
 export {MapProvider} from './components/use-map';
 
@@ -105,8 +112,7 @@ export default Map;
 
 // Types
 export * from './types/public';
-export type {SourceProps} from './components/source';
-export type {LayerProps} from './components/layer';
+export * from './types/style-spec-mapbox';
 
 // Events
 export type MapEvent = events.MapEvent<MapboxMap>;

--- a/src/exports-mapbox.ts
+++ b/src/exports-mapbox.ts
@@ -42,17 +42,18 @@ import {default as _Source, SourceProps as _SourceProps} from './components/sour
 import {useMap as _useMap} from './components/use-map';
 import type {MapRef as _MapRef} from './mapbox/create-ref';
 import type * as events from './types/events';
+import type {MapCallbacks} from './types/events-mapbox';
 
 export function useMap() {
   return _useMap<MapboxMap>();
 }
 
-export type MapProps = _MapProps<MapboxOptions, MapboxStyle, MapboxMap>;
+export type MapProps = _MapProps<MapboxOptions, MapboxStyle, MapCallbacks, MapboxMap>;
 export type MapRef = _MapRef<MapboxMap>;
 const mapLib = import('mapbox-gl');
 export const Map = (() => {
   return React.forwardRef(function Map(props: MapProps, ref: React.Ref<MapRef>) {
-    return _Map(props, ref, mapLib);
+    return _Map<MapboxOptions, MapboxStyle, MapCallbacks, MapboxMap>(props, ref, mapLib);
   });
 })();
 
@@ -115,17 +116,19 @@ export * from './types/public';
 export * from './types/style-spec-mapbox';
 
 // Events
-export type MapEvent = events.MapEvent<MapboxMap>;
-export type ErrorEvent = events.ErrorEvent<MapboxMap>;
-export type MapStyleDataEvent = events.MapStyleDataEvent<MapboxMap>;
-export type MapSourceDataEvent = events.MapSourceDataEvent<MapboxMap>;
-export type MapMouseEvent = events.MapMouseEvent<MapboxMap>;
-export type MapLayerMouseEvent = events.MapLayerMouseEvent<MapboxMap>;
-export type MapTouchEvent = events.MapTouchEvent<MapboxMap>;
-export type MapLayerTouchEvent = events.MapLayerTouchEvent<MapboxMap>;
-export type MapWheelEvent = events.MapWheelEvent<MapboxMap>;
-export type MapBoxZoomEvent = events.MapBoxZoomEvent<MapboxMap>;
-export type ViewStateChangeEvent = events.ViewStateChangeEvent<MapboxMap>;
+export {
+  MapEvent,
+  MapMouseEvent,
+  MapLayerMouseEvent,
+  MapTouchEvent,
+  MapLayerTouchEvent,
+  MapStyleDataEvent,
+  MapSourceDataEvent,
+  MapWheelEvent,
+  MapBoxZoomEvent,
+  ErrorEvent,
+  ViewStateChangeEvent
+} from './types/events-mapbox';
 export type PopupEvent = events.PopupEvent<MapboxPopup>;
 export type MarkerEvent = events.MarkerEvent<MapboxMarker>;
 export type MarkerDragEvent = events.MarkerDragEvent<MapboxMarker>;

--- a/src/exports-mapbox.ts
+++ b/src/exports-mapbox.ts
@@ -116,7 +116,7 @@ export * from './types/public';
 export * from './types/style-spec-mapbox';
 
 // Events
-export {
+export type {
   MapEvent,
   MapMouseEvent,
   MapLayerMouseEvent,

--- a/src/exports-maplibre.ts
+++ b/src/exports-maplibre.ts
@@ -42,17 +42,18 @@ import {default as _Source, SourceProps as _SourceProps} from './components/sour
 import {useMap as _useMap} from './components/use-map';
 import type {MapRef as _MapRef} from './mapbox/create-ref';
 import type * as events from './types/events';
+import type {MapCallbacks} from './types/events-maplibre';
 
 export function useMap() {
   return _useMap<MaplibreMap>();
 }
 
-export type MapProps = _MapProps<MapOptions, MapboxStyle, MaplibreMap>;
+export type MapProps = _MapProps<MapOptions, MapboxStyle, MapCallbacks, MaplibreMap>;
 export type MapRef = _MapRef<MaplibreMap>;
 const mapLib = import('maplibre-gl');
 export const Map = (() => {
   return React.forwardRef(function Map(props: MapProps, ref: React.Ref<MapRef>) {
-    return _Map(props, ref, mapLib);
+    return _Map<MapOptions, MapboxStyle, MapCallbacks, MaplibreMap>(props, ref, mapLib);
   });
 })();
 
@@ -115,17 +116,19 @@ export * from './types/public';
 export * from './types/style-spec-maplibre';
 
 // Events
-export type MapEvent = events.MapEvent<MaplibreMap>;
-export type ErrorEvent = events.ErrorEvent<MaplibreMap>;
-export type MapStyleDataEvent = events.MapStyleDataEvent<MaplibreMap>;
-export type MapSourceDataEvent = events.MapSourceDataEvent<MaplibreMap>;
-export type MapMouseEvent = events.MapMouseEvent<MaplibreMap>;
-export type MapLayerMouseEvent = events.MapLayerMouseEvent<MaplibreMap>;
-export type MapTouchEvent = events.MapTouchEvent<MaplibreMap>;
-export type MapLayerTouchEvent = events.MapLayerTouchEvent<MaplibreMap>;
-export type MapWheelEvent = events.MapWheelEvent<MaplibreMap>;
-export type MapBoxZoomEvent = events.MapBoxZoomEvent<MaplibreMap>;
-export type ViewStateChangeEvent = events.ViewStateChangeEvent<MaplibreMap>;
+export {
+  MapEvent,
+  MapMouseEvent,
+  MapLayerMouseEvent,
+  MapTouchEvent,
+  MapLayerTouchEvent,
+  MapStyleDataEvent,
+  MapSourceDataEvent,
+  MapWheelEvent,
+  MapBoxZoomEvent,
+  ErrorEvent,
+  ViewStateChangeEvent
+} from './types/events-maplibre';
 export type PopupEvent = events.PopupEvent<MaplibrePopup>;
 export type MarkerEvent = events.MarkerEvent<MaplibreMarker>;
 export type MarkerDragEvent = events.MarkerDragEvent<MaplibreMarker>;

--- a/src/exports-maplibre.ts
+++ b/src/exports-maplibre.ts
@@ -116,7 +116,7 @@ export * from './types/public';
 export * from './types/style-spec-maplibre';
 
 // Events
-export {
+export type {
   MapEvent,
   MapMouseEvent,
   MapLayerMouseEvent,

--- a/src/exports-maplibre.ts
+++ b/src/exports-maplibre.ts
@@ -12,6 +12,7 @@ import type {
   NavigationControl as MaplibreNavigationControl,
   ScaleControl as MaplibreScaleControl
 } from 'maplibre-gl';
+import {MapboxStyle, AnyLayer, AnySource} from './types/style-spec-maplibre';
 
 import {default as _Map, MapProps as _MapProps} from './components/map';
 import {default as _Marker, MarkerProps as _MarkerProps} from './components/marker';
@@ -36,6 +37,8 @@ import {
   default as _ScaleControl,
   ScaleControlProps as _ScaleControlProps
 } from './components/scale-control';
+import {default as _Layer, LayerProps as _LayerProps} from './components/layer';
+import {default as _Source, SourceProps as _SourceProps} from './components/source';
 import {useMap as _useMap} from './components/use-map';
 import type {MapRef as _MapRef} from './mapbox/create-ref';
 import type * as events from './types/events';
@@ -44,7 +47,7 @@ export function useMap() {
   return _useMap<MaplibreMap>();
 }
 
-export type MapProps = _MapProps<MapOptions, MaplibreMap>;
+export type MapProps = _MapProps<MapOptions, MapboxStyle, MaplibreMap>;
 export type MapRef = _MapRef<MaplibreMap>;
 const mapLib = import('maplibre-gl');
 export const Map = (() => {
@@ -96,8 +99,12 @@ export const ScaleControl = _ScaleControl as (
   props: ScaleControlProps
 ) => React.ReactElement | null;
 
-export {default as Source} from './components/source';
-export {default as Layer} from './components/layer';
+export type LayerProps = _LayerProps<AnyLayer>;
+export const Layer = _Layer as (props: LayerProps) => React.ReactElement | null;
+
+export type SourceProps = _SourceProps<AnySource>;
+export const Source = _Source as (props: SourceProps) => React.ReactElement | null;
+
 export {default as useControl} from './components/use-control';
 export {MapProvider} from './components/use-map';
 
@@ -105,8 +112,7 @@ export default Map;
 
 // Types
 export * from './types/public';
-export type {SourceProps} from './components/source';
-export type {LayerProps} from './components/layer';
+export * from './types/style-spec-maplibre';
 
 // Events
 export type MapEvent = events.MapEvent<MaplibreMap>;

--- a/src/mapbox/create-ref.ts
+++ b/src/mapbox/create-ref.ts
@@ -1,4 +1,4 @@
-import type {MapInstance, MapInstanceInternal, LngLatLike, PointLike} from '../types';
+import type {MapInstance, MapInstanceInternal, MapStyle, LngLatLike, PointLike} from '../types';
 import type Mapbox from './mapbox';
 
 /** These methods may break the react binding if called directly */
@@ -29,8 +29,8 @@ export type MapRef<MapT extends MapInstance> = {
   getMap(): MapT;
 } & Omit<MapT, typeof skipMethods[number]>;
 
-export default function createRef<MapT extends MapInstance>(
-  mapInstance: Mapbox<MapT>
+export default function createRef<StyleT extends MapStyle, MapT extends MapInstance>(
+  mapInstance: Mapbox<StyleT, MapT>
 ): MapRef<MapT> {
   if (!mapInstance) {
     return null;

--- a/src/mapbox/create-ref.ts
+++ b/src/mapbox/create-ref.ts
@@ -1,4 +1,11 @@
-import type {MapInstance, MapInstanceInternal, MapStyle, LngLatLike, PointLike} from '../types';
+import type {
+  MapInstance,
+  MapInstanceInternal,
+  MapStyle,
+  Callbacks,
+  LngLatLike,
+  PointLike
+} from '../types';
 import type Mapbox from './mapbox';
 
 /** These methods may break the react binding if called directly */
@@ -29,9 +36,11 @@ export type MapRef<MapT extends MapInstance> = {
   getMap(): MapT;
 } & Omit<MapT, typeof skipMethods[number]>;
 
-export default function createRef<StyleT extends MapStyle, MapT extends MapInstance>(
-  mapInstance: Mapbox<StyleT, MapT>
-): MapRef<MapT> {
+export default function createRef<
+  StyleT extends MapStyle,
+  CallbacksT extends Callbacks,
+  MapT extends MapInstance
+>(mapInstance: Mapbox<StyleT, CallbacksT, MapT>): MapRef<MapT> {
   if (!mapInstance) {
     return null;
   }

--- a/src/mapbox/mapbox.ts
+++ b/src/mapbox/mapbox.ts
@@ -17,15 +17,10 @@ import type {
   MapStyle,
   ImmutableLike,
   LngLatBoundsLike,
-  MapMouseEvent,
-  MapLayerMouseEvent,
-  MapLayerTouchEvent,
-  MapWheelEvent,
-  MapBoxZoomEvent,
-  MapStyleDataEvent,
-  MapSourceDataEvent,
+  Callbacks,
   MapEvent,
   ErrorEvent,
+  MapMouseEvent,
   MapGeoJSONFeature,
   MapInstance,
   MapInstanceInternal
@@ -33,102 +28,56 @@ import type {
 
 export type MapboxProps<
   StyleT extends MapStyle = MapStyle,
-  MapT extends MapInstance = MapInstance
-> = Partial<ViewState> & {
-  // Init options
-  mapboxAccessToken?: string;
+  CallbacksT extends Callbacks = {}
+> = Partial<ViewState> &
+  CallbacksT & {
+    // Init options
+    mapboxAccessToken?: string;
 
-  /** Camera options used when constructing the Map instance */
-  initialViewState?: Partial<ViewState> & {
-    /** The initial bounds of the map. If bounds is specified, it overrides longitude, latitude and zoom options. */
-    bounds?: LngLatBoundsLike;
-    /** A fitBounds options object to use only when setting the bounds option. */
-    fitBoundsOptions?: {
-      offset?: PointLike;
-      minZoom?: number;
-      maxZoom?: number;
-      padding?: number | PaddingOptions;
+    /** Camera options used when constructing the Map instance */
+    initialViewState?: Partial<ViewState> & {
+      /** The initial bounds of the map. If bounds is specified, it overrides longitude, latitude and zoom options. */
+      bounds?: LngLatBoundsLike;
+      /** A fitBounds options object to use only when setting the bounds option. */
+      fitBoundsOptions?: {
+        offset?: PointLike;
+        minZoom?: number;
+        maxZoom?: number;
+        padding?: number | PaddingOptions;
+      };
     };
+
+    /** If provided, render into an external WebGL context */
+    gl?: WebGLRenderingContext;
+
+    /** For external controller to override the camera state */
+    viewState?: ViewState & {
+      width: number;
+      height: number;
+    };
+
+    // Styling
+
+    /** Mapbox style */
+    mapStyle?: string | StyleT | ImmutableLike<StyleT>;
+    /** Enable diffing when the map style changes
+     * @default true
+     */
+    styleDiffing?: boolean;
+    /** The fog property of the style. Must conform to the Fog Style Specification .
+     * If `undefined` is provided, removes the fog from the map. */
+    fog?: StyleT['fog'];
+    /** Light properties of the map. */
+    light?: StyleT['light'];
+    /** Terrain property of the style. Must conform to the Terrain Style Specification .
+     * If `undefined` is provided, removes terrain from the map. */
+    terrain?: StyleT['terrain'];
+
+    /** Default layers to query on pointer events */
+    interactiveLayerIds?: string[];
+    /** CSS cursor */
+    cursor?: string;
   };
-
-  /** If provided, render into an external WebGL context */
-  gl?: WebGLRenderingContext;
-
-  /** For external controller to override the camera state */
-  viewState?: ViewState & {
-    width: number;
-    height: number;
-  };
-
-  // Styling
-
-  /** Mapbox style */
-  mapStyle?: string | StyleT | ImmutableLike<StyleT>;
-  /** Enable diffing when the map style changes
-   * @default true
-   */
-  styleDiffing?: boolean;
-  /** The fog property of the style. Must conform to the Fog Style Specification .
-   * If `undefined` is provided, removes the fog from the map. */
-  fog?: StyleT['fog'];
-  /** Light properties of the map. */
-  light?: StyleT['light'];
-  /** Terrain property of the style. Must conform to the Terrain Style Specification .
-   * If `undefined` is provided, removes terrain from the map. */
-  terrain?: StyleT['terrain'];
-
-  /** Default layers to query on pointer events */
-  interactiveLayerIds?: string[];
-  /** CSS cursor */
-  cursor?: string;
-
-  // Callbacks
-  onMouseDown?: (e: MapLayerMouseEvent<MapT>) => void;
-  onMouseUp?: (e: MapLayerMouseEvent<MapT>) => void;
-  onMouseOver?: (e: MapLayerMouseEvent<MapT>) => void;
-  onMouseMove?: (e: MapLayerMouseEvent<MapT>) => void;
-  onClick?: (e: MapLayerMouseEvent<MapT>) => void;
-  onDblClick?: (e: MapLayerMouseEvent<MapT>) => void;
-  onMouseEnter?: (e: MapLayerMouseEvent<MapT>) => void;
-  onMouseLeave?: (e: MapLayerMouseEvent<MapT>) => void;
-  onMouseOut?: (e: MapLayerMouseEvent<MapT>) => void;
-  onContextMenu?: (e: MapLayerMouseEvent<MapT>) => void;
-  onTouchStart?: (e: MapLayerTouchEvent<MapT>) => void;
-  onTouchEnd?: (e: MapLayerTouchEvent<MapT>) => void;
-  onTouchMove?: (e: MapLayerTouchEvent<MapT>) => void;
-  onTouchCancel?: (e: MapLayerTouchEvent<MapT>) => void;
-
-  onMoveStart?: (e: ViewStateChangeEvent<MapT>) => void;
-  onMove?: (e: ViewStateChangeEvent<MapT>) => void;
-  onMoveEnd?: (e: ViewStateChangeEvent<MapT>) => void;
-  onDragStart?: (e: ViewStateChangeEvent<MapT>) => void;
-  onDrag?: (e: ViewStateChangeEvent<MapT>) => void;
-  onDragEnd?: (e: ViewStateChangeEvent<MapT>) => void;
-  onZoomStart?: (e: ViewStateChangeEvent<MapT>) => void;
-  onZoom?: (e: ViewStateChangeEvent<MapT>) => void;
-  onZoomEnd?: (e: ViewStateChangeEvent<MapT>) => void;
-  onRotateStart?: (e: ViewStateChangeEvent<MapT>) => void;
-  onRotate?: (e: ViewStateChangeEvent<MapT>) => void;
-  onRotateEnd?: (e: ViewStateChangeEvent<MapT>) => void;
-  onPitchStart?: (e: ViewStateChangeEvent<MapT>) => void;
-  onPitch?: (e: ViewStateChangeEvent<MapT>) => void;
-  onPitchEnd?: (e: ViewStateChangeEvent<MapT>) => void;
-
-  onWheel?: (e: MapWheelEvent<MapT>) => void;
-  onBoxZoomStart?: (e: MapBoxZoomEvent<MapT>) => void;
-  onBoxZoomEnd?: (e: MapBoxZoomEvent<MapT>) => void;
-  onBoxZoomCancel?: (e: MapBoxZoomEvent<MapT>) => void;
-
-  onResize?: (e: MapEvent<MapT>) => void;
-  onLoad?: (e: MapEvent<MapT>) => void;
-  onRender?: (e: MapEvent<MapT>) => void;
-  onIdle?: (e: MapEvent<MapT>) => void;
-  onError?: (e: ErrorEvent<MapT>) => void;
-  onRemove?: (e: MapEvent<MapT>) => void;
-  onData?: (e: MapStyleDataEvent<MapT> | MapSourceDataEvent<MapT>) => void;
-  onStyleData?: (e: MapStyleDataEvent<MapT>) => void;
-  onSourceData?: (e: MapSourceDataEvent<MapT>) => void;
-};
 
 const DEFAULT_STYLE = {version: 8, sources: {}, layers: []} as MapStyle;
 
@@ -205,13 +154,14 @@ const handlerNames = [
  */
 export default class Mapbox<
   StyleT extends MapStyle = MapStyle,
+  CallbacksT extends Callbacks = {},
   MapT extends MapInstance = MapInstance
 > {
   private _MapClass: {new (options: any): MapInstance};
   // mapboxgl.Map instance
   private _map: MapInstanceInternal<MapT> = null;
   // User-supplied props
-  props: MapboxProps<StyleT, MapT>;
+  props: MapboxProps<StyleT, CallbacksT>;
 
   // Mapbox map is stateful.
   // During method calls/user interactions, map.transform is mutated and
@@ -241,7 +191,7 @@ export default class Mapbox<
 
   constructor(
     MapClass: {new (options: any): MapInstance},
-    props: MapboxProps<StyleT, MapT>,
+    props: MapboxProps<StyleT, CallbacksT>,
     container: HTMLDivElement
   ) {
     this._MapClass = MapClass;
@@ -257,7 +207,7 @@ export default class Mapbox<
     return this._renderTransform;
   }
 
-  setProps(props: MapboxProps<StyleT, MapT>) {
+  setProps(props: MapboxProps<StyleT, CallbacksT>) {
     const oldProps = this.props;
     this.props = props;
 
@@ -279,11 +229,11 @@ export default class Mapbox<
     }
   }
 
-  static reuse<StyleT extends MapStyle, MapT extends MapInstance>(
-    props: MapboxProps<StyleT, MapT>,
+  static reuse<StyleT extends MapStyle, CallbacksT extends Callbacks, MapT extends MapInstance>(
+    props: MapboxProps<StyleT, CallbacksT>,
     container: HTMLDivElement
-  ): Mapbox<StyleT, MapT> {
-    const that = Mapbox.savedMaps.pop() as Mapbox<StyleT, MapT>;
+  ): Mapbox<StyleT, CallbacksT, MapT> {
+    const that = Mapbox.savedMaps.pop() as Mapbox<StyleT, CallbacksT, MapT>;
     if (!that) {
       return null;
     }
@@ -464,7 +414,7 @@ export default class Mapbox<
      @param {object} nextProps
      @returns {bool} true if size has changed
    */
-  _updateSize(nextProps: MapboxProps<StyleT, MapT>): boolean {
+  _updateSize(nextProps: MapboxProps<StyleT>): boolean {
     // Check if size is controlled
     const {viewState} = nextProps;
     if (viewState) {
@@ -483,7 +433,7 @@ export default class Mapbox<
      @param {bool} triggerEvents - should fire camera events
      @returns {bool} true if anything is changed
    */
-  _updateViewState(nextProps: MapboxProps<StyleT, MapT>, triggerEvents: boolean): boolean {
+  _updateViewState(nextProps: MapboxProps<StyleT>, triggerEvents: boolean): boolean {
     if (this._internalUpdate) {
       return false;
     }
@@ -530,10 +480,7 @@ export default class Mapbox<
      @param {object} currProps
      @returns {bool} true if anything is changed
    */
-  _updateSettings(
-    nextProps: MapboxProps<StyleT, MapT>,
-    currProps: MapboxProps<StyleT, MapT>
-  ): boolean {
+  _updateSettings(nextProps: MapboxProps<StyleT>, currProps: MapboxProps<StyleT>): boolean {
     const map = this._map;
     let changed = false;
     for (const propName of settingNames) {
@@ -551,10 +498,7 @@ export default class Mapbox<
      @param {object} currProps
      @returns {bool} true if style is changed
    */
-  _updateStyle(
-    nextProps: MapboxProps<StyleT, MapT>,
-    currProps: MapboxProps<StyleT, MapT>
-  ): boolean {
+  _updateStyle(nextProps: MapboxProps<StyleT>, currProps: MapboxProps<StyleT>): boolean {
     if (nextProps.cursor !== currProps.cursor) {
       this._map.getCanvas().style.cursor = nextProps.cursor;
     }
@@ -578,10 +522,7 @@ export default class Mapbox<
      @param {object} currProps
      @returns {bool} true if anything is changed
    */
-  _updateStyleComponents(
-    nextProps: MapboxProps<StyleT, MapT>,
-    currProps: MapboxProps<StyleT, MapT>
-  ): boolean {
+  _updateStyleComponents(nextProps: MapboxProps<StyleT>, currProps: MapboxProps<StyleT>): boolean {
     const map = this._map;
     let changed = false;
     if (map.isStyleLoaded()) {
@@ -612,10 +553,7 @@ export default class Mapbox<
      @param {object} currProps
      @returns {bool} true if anything is changed
    */
-  _updateHandlers(
-    nextProps: MapboxProps<StyleT, MapT>,
-    currProps: MapboxProps<StyleT, MapT>
-  ): boolean {
+  _updateHandlers(nextProps: MapboxProps<StyleT>, currProps: MapboxProps<StyleT>): boolean {
     const map = this._map;
     let changed = false;
     for (const propName of handlerNames) {
@@ -682,7 +620,7 @@ export default class Mapbox<
     }
   }
 
-  _onPointerEvent = (e: MapLayerMouseEvent<MapT> | MapLayerTouchEvent<MapT>) => {
+  _onPointerEvent = (e: MapMouseEvent<MapT> | MapMouseEvent<MapT>) => {
     if (e.type === 'mousemove' || e.type === 'mouseout') {
       this._updateHover(e);
     }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,5 +1,5 @@
 import type GeoJSON from 'geojson';
-import type {AnyLayer} from './style-spec';
+import type {AnyLayer} from './style-spec-maplibre';
 
 /* Data types */
 
@@ -13,7 +13,7 @@ export type PointLike = Point | [number, number];
 export interface LngLat {
   lng: number;
   lat: number;
-  
+
   wrap(): LngLat;
   /** Return a LngLat as an array */
   toArray(): number[];

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,5 +1,4 @@
 import type GeoJSON from 'geojson';
-import type {AnyLayer} from './style-spec-maplibre';
 
 /* Data types */
 
@@ -102,7 +101,7 @@ export interface ImmutableLike<T> {
 }
 
 export type MapGeoJSONFeature = GeoJSON.Feature<GeoJSON.Geometry> & {
-  layer: AnyLayer;
+  layer: any;
   source: string;
   sourceLayer: string;
   state: {[key: string]: any};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -2,6 +2,8 @@ import type GeoJSON from 'geojson';
 import type {AnyLayer} from './style-spec';
 
 /* Data types */
+
+/** @mapbox/point-geometry */
 export interface Point {
   x: number;
   y: number;
@@ -11,6 +13,15 @@ export type PointLike = Point | [number, number];
 export interface LngLat {
   lng: number;
   lat: number;
+  
+  wrap(): LngLat;
+  /** Return a LngLat as an array */
+  toArray(): number[];
+  /** Return a LngLat as a string */
+  toString(): string;
+  /** Returns the approximate distance between a pair of coordinates in meters
+   * Uses the Haversine Formula (from R.W. Sinnott, "Virtues of the Haversine", Sky and Telescope, vol. 68, no. 2, 1984, p. 159) */
+  distanceTo(lngLat: LngLat): number;
 }
 export type LngLatLike =
   | [number, number]
@@ -23,6 +34,9 @@ export interface LngLatBounds {
   ne: LngLatLike;
 
   contains(lnglat: LngLatLike): boolean;
+  setNorthEast(ne: LngLatLike): this;
+  setSouthWest(sw: LngLatLike): this;
+  extend(obj: LngLatLike | LngLatBoundsLike): this;
 
   getCenter(): LngLat;
   getSouthWest(): LngLat;
@@ -34,6 +48,10 @@ export interface LngLatBounds {
   getSouth(): number;
   getEast(): number;
   getNorth(): number;
+
+  toArray(): number[][];
+  toString(): string;
+  isEmpty(): boolean;
 }
 export type LngLatBoundsLike =
   | LngLatBounds

--- a/src/types/events-mapbox.ts
+++ b/src/types/events-mapbox.ts
@@ -1,0 +1,76 @@
+import {
+  Map,
+  MapboxEvent as MapEvent,
+  MapMouseEvent,
+  MapLayerMouseEvent,
+  MapTouchEvent,
+  MapLayerTouchEvent,
+  MapStyleDataEvent,
+  MapSourceDataEvent,
+  MapWheelEvent,
+  MapBoxZoomEvent
+} from 'mapbox-gl';
+import {ErrorEvent as _ErrorEvent, ViewStateChangeEvent as _ViewStateChangeEvent} from './events';
+
+export type {
+  MapEvent,
+  MapMouseEvent,
+  MapLayerMouseEvent,
+  MapTouchEvent,
+  MapLayerTouchEvent,
+  MapStyleDataEvent,
+  MapSourceDataEvent,
+  MapWheelEvent,
+  MapBoxZoomEvent
+};
+
+export type ErrorEvent = _ErrorEvent<Map>;
+export type ViewStateChangeEvent = _ViewStateChangeEvent<Map>;
+
+export type MapCallbacks = {
+  onMouseDown?: (e: MapLayerMouseEvent) => void;
+  onMouseUp?: (e: MapLayerMouseEvent) => void;
+  onMouseOver?: (e: MapLayerMouseEvent) => void;
+  onMouseMove?: (e: MapLayerMouseEvent) => void;
+  onClick?: (e: MapLayerMouseEvent) => void;
+  onDblClick?: (e: MapLayerMouseEvent) => void;
+  onMouseEnter?: (e: MapLayerMouseEvent) => void;
+  onMouseLeave?: (e: MapLayerMouseEvent) => void;
+  onMouseOut?: (e: MapLayerMouseEvent) => void;
+  onContextMenu?: (e: MapLayerMouseEvent) => void;
+  onTouchStart?: (e: MapLayerTouchEvent) => void;
+  onTouchEnd?: (e: MapLayerTouchEvent) => void;
+  onTouchMove?: (e: MapLayerTouchEvent) => void;
+  onTouchCancel?: (e: MapLayerTouchEvent) => void;
+
+  onMoveStart?: (e: ViewStateChangeEvent) => void;
+  onMove?: (e: ViewStateChangeEvent) => void;
+  onMoveEnd?: (e: ViewStateChangeEvent) => void;
+  onDragStart?: (e: ViewStateChangeEvent) => void;
+  onDrag?: (e: ViewStateChangeEvent) => void;
+  onDragEnd?: (e: ViewStateChangeEvent) => void;
+  onZoomStart?: (e: ViewStateChangeEvent) => void;
+  onZoom?: (e: ViewStateChangeEvent) => void;
+  onZoomEnd?: (e: ViewStateChangeEvent) => void;
+  onRotateStart?: (e: ViewStateChangeEvent) => void;
+  onRotate?: (e: ViewStateChangeEvent) => void;
+  onRotateEnd?: (e: ViewStateChangeEvent) => void;
+  onPitchStart?: (e: ViewStateChangeEvent) => void;
+  onPitch?: (e: ViewStateChangeEvent) => void;
+  onPitchEnd?: (e: ViewStateChangeEvent) => void;
+
+  onWheel?: (e: MapWheelEvent) => void;
+  onBoxZoomStart?: (e: MapBoxZoomEvent) => void;
+  onBoxZoomEnd?: (e: MapBoxZoomEvent) => void;
+  onBoxZoomCancel?: (e: MapBoxZoomEvent) => void;
+
+  onResize?: (e: MapEvent) => void;
+  onLoad?: (e: MapEvent) => void;
+  onRender?: (e: MapEvent) => void;
+  onIdle?: (e: MapEvent) => void;
+  onError?: (e: ErrorEvent) => void;
+  onRemove?: (e: MapEvent) => void;
+  onData?: (e: MapStyleDataEvent | MapSourceDataEvent) => void;
+  onStyleData?: (e: MapStyleDataEvent) => void;
+  onSourceData?: (e: MapSourceDataEvent) => void;
+};

--- a/src/types/events-maplibre.ts
+++ b/src/types/events-maplibre.ts
@@ -1,0 +1,76 @@
+import {
+  Map,
+  MapLibreEvent as MapEvent,
+  MapMouseEvent,
+  MapLayerMouseEvent,
+  MapTouchEvent,
+  MapLayerTouchEvent,
+  MapStyleDataEvent,
+  MapSourceDataEvent,
+  MapWheelEvent,
+  MapLibreZoomEvent as MapBoxZoomEvent
+} from 'maplibre-gl';
+import {ErrorEvent as _ErrorEvent, ViewStateChangeEvent as _ViewStateChangeEvent} from './events';
+
+export type {
+  MapEvent,
+  MapMouseEvent,
+  MapLayerMouseEvent,
+  MapTouchEvent,
+  MapLayerTouchEvent,
+  MapStyleDataEvent,
+  MapSourceDataEvent,
+  MapWheelEvent,
+  MapBoxZoomEvent
+};
+
+export type ErrorEvent = _ErrorEvent<Map>;
+export type ViewStateChangeEvent = _ViewStateChangeEvent<Map>;
+
+export type MapCallbacks = {
+  onMouseDown?: (e: MapLayerMouseEvent) => void;
+  onMouseUp?: (e: MapLayerMouseEvent) => void;
+  onMouseOver?: (e: MapLayerMouseEvent) => void;
+  onMouseMove?: (e: MapLayerMouseEvent) => void;
+  onClick?: (e: MapLayerMouseEvent) => void;
+  onDblClick?: (e: MapLayerMouseEvent) => void;
+  onMouseEnter?: (e: MapLayerMouseEvent) => void;
+  onMouseLeave?: (e: MapLayerMouseEvent) => void;
+  onMouseOut?: (e: MapLayerMouseEvent) => void;
+  onContextMenu?: (e: MapLayerMouseEvent) => void;
+  onTouchStart?: (e: MapLayerTouchEvent) => void;
+  onTouchEnd?: (e: MapLayerTouchEvent) => void;
+  onTouchMove?: (e: MapLayerTouchEvent) => void;
+  onTouchCancel?: (e: MapLayerTouchEvent) => void;
+
+  onMoveStart?: (e: ViewStateChangeEvent) => void;
+  onMove?: (e: ViewStateChangeEvent) => void;
+  onMoveEnd?: (e: ViewStateChangeEvent) => void;
+  onDragStart?: (e: ViewStateChangeEvent) => void;
+  onDrag?: (e: ViewStateChangeEvent) => void;
+  onDragEnd?: (e: ViewStateChangeEvent) => void;
+  onZoomStart?: (e: ViewStateChangeEvent) => void;
+  onZoom?: (e: ViewStateChangeEvent) => void;
+  onZoomEnd?: (e: ViewStateChangeEvent) => void;
+  onRotateStart?: (e: ViewStateChangeEvent) => void;
+  onRotate?: (e: ViewStateChangeEvent) => void;
+  onRotateEnd?: (e: ViewStateChangeEvent) => void;
+  onPitchStart?: (e: ViewStateChangeEvent) => void;
+  onPitch?: (e: ViewStateChangeEvent) => void;
+  onPitchEnd?: (e: ViewStateChangeEvent) => void;
+
+  onWheel?: (e: MapWheelEvent) => void;
+  onBoxZoomStart?: (e: MapBoxZoomEvent) => void;
+  onBoxZoomEnd?: (e: MapBoxZoomEvent) => void;
+  onBoxZoomCancel?: (e: MapBoxZoomEvent) => void;
+
+  onResize?: (e: MapEvent) => void;
+  onLoad?: (e: MapEvent) => void;
+  onRender?: (e: MapEvent) => void;
+  onIdle?: (e: MapEvent) => void;
+  onError?: (e: ErrorEvent) => void;
+  onRemove?: (e: MapEvent) => void;
+  onData?: (e: MapStyleDataEvent | MapSourceDataEvent) => void;
+  onStyleData?: (e: MapStyleDataEvent) => void;
+  onSourceData?: (e: MapSourceDataEvent) => void;
+};

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -6,7 +6,7 @@ import type {
   PopupInstance,
   GeolocateControlInstance
 } from './lib';
-import type {AnySource} from './style-spec';
+import type {AnySource} from './style-spec-maplibre';
 
 export interface MapEvent<SourceT extends Evented, OriginalEventT = undefined> {
   type: string;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,4 +1,4 @@
-import type {ViewState, Point, LngLat, LngLatBounds, MapGeoJSONFeature} from './common';
+import type {ViewState, Point, LngLat, MapGeoJSONFeature} from './common';
 import type {
   MapInstance,
   Evented,
@@ -6,7 +6,10 @@ import type {
   PopupInstance,
   GeolocateControlInstance
 } from './lib';
-import type {AnySource} from './style-spec-maplibre';
+
+export interface Callbacks {
+  [key: `on${string}`]: Function;
+}
 
 export interface MapEvent<SourceT extends Evented, OriginalEventT = undefined> {
   type: string;
@@ -19,80 +22,10 @@ export type ErrorEvent<MapT extends MapInstance> = MapEvent<MapT> & {
   error: Error;
 };
 
-export type MapStyleDataEvent<MapT extends MapInstance> = MapEvent<MapT> & {
-  dataType: 'style';
-};
-
-export type MapSourceDataEvent<MapT extends MapInstance> = MapEvent<MapT> & {
-  dataType: 'source';
-  isSourceLoaded: boolean;
-  source: AnySource;
-  sourceId: string;
-  sourceDataType: 'metadata' | 'content';
-  tile: any;
-  coord: {
-    canonical: {
-      x: number;
-      y: number;
-      z: number;
-      key: number;
-    };
-    wrap: number;
-    key: number;
-  };
-};
-
 export type MapMouseEvent<MapT extends MapInstance> = MapEvent<MapT, MouseEvent> & {
-  type:
-    | 'mousedown'
-    | 'mouseup'
-    | 'click'
-    | 'dblclick'
-    | 'mousemove'
-    | 'mouseover'
-    | 'mouseenter'
-    | 'mouseleave'
-    | 'mouseout'
-    | 'contextmenu';
-
   point: Point;
   lngLat: LngLat;
-
-  preventDefault(): void;
-  defaultPrevented: boolean;
-};
-
-export type MapLayerMouseEvent<MapT extends MapInstance> = MapMouseEvent<MapT> & {
-  features?: MapGeoJSONFeature[] | undefined;
-};
-
-export type MapTouchEvent<MapT extends MapInstance> = MapEvent<MapT, TouchEvent> & {
-  type: 'touchstart' | 'touchend' | 'touchcancel';
-
-  point: Point;
-  lngLat: LngLat;
-  points: Point[];
-  lngLats: LngLat[];
-
-  preventDefault(): void;
-  defaultPrevented: boolean;
-};
-
-export type MapLayerTouchEvent<MapT extends MapInstance> = MapTouchEvent<MapT> & {
-  features?: MapGeoJSONFeature[] | undefined;
-};
-
-export type MapWheelEvent<MapT extends MapInstance> = MapEvent<MapT, WheelEvent> & {
-  type: 'wheel';
-
-  preventDefault(): void;
-  defaultPrevented: boolean;
-};
-
-export type MapBoxZoomEvent<MapT extends MapInstance> = MapEvent<MapT, MouseEvent> & {
-  type: 'boxzoomstart' | 'boxzoomend' | 'boxzoomcancel';
-
-  boxZoomBounds: LngLatBounds;
+  features?: MapGeoJSONFeature[];
 };
 
 export type ViewStateChangeEvent<MapT extends MapInstance> =

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,9 +3,45 @@ export * from './events';
 
 import type GeoJSON from 'geojson';
 import type {CustomSourceImplementation} from './lib';
-import type {ImageSource} from './style-spec';
 
 // Internal: source implementations
+
+export interface ISource {
+  type: string;
+}
+
+export interface ILayer {
+  id: string;
+  type: string;
+
+  metadata?: any;
+  source?: unknown;
+
+  minzoom?: number;
+  maxzoom?: number;
+
+  filter?: any;
+  layout?: {
+    [property: string]: any;
+  };
+  paint?: {
+    [property: string]: any;
+  };
+}
+
+export interface MapStyle {
+  name?: string;
+  metadata?: unknown;
+  version: number;
+  layers: ILayer[];
+  sources: {
+    [sourceName: string]: object;
+  };
+
+  fog?: any;
+  terrain?: any;
+  light?: any;
+}
 
 export interface GeoJSONSourceImplementation {
   type: 'geojson';
@@ -16,7 +52,7 @@ export interface GeoJSONSourceImplementation {
 
 export interface ImageSourceImplemtation {
   type: 'image';
-  updateImage(options: Omit<ImageSource, 'type'>): this;
+  updateImage(options: {url?: string; coordinates?: number[][]}): this;
   setCoordinates(coordinates: number[][]): this;
 }
 

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -1,5 +1,4 @@
 import type {PaddingOptions, LngLat, Point, LngLatLike, PointLike} from './common';
-import type {Projection} from './style-spec';
 
 export interface IControl<MapT extends MapInstance = MapInstance> {
   onAdd(map: MapT): HTMLElement;
@@ -220,8 +219,8 @@ export type Transform = {
   pointLocation: (p: Point) => LngLat;
 
   // Mapbox only
-  getProjection?: () => Projection;
-  setProjection?: (projection: Projection) => void;
+  getProjection?: () => any;
+  setProjection?: (projection: any) => void;
 };
 
 export type MapInstanceInternal<MapT extends MapInstance> = MapT & {

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -1,3 +1,2 @@
 export * from './common';
-export * from './style-spec';
 export * from './lib';

--- a/src/types/style-spec-mapbox.ts
+++ b/src/types/style-spec-mapbox.ts
@@ -1,0 +1,80 @@
+/*
+ * Mapbox Style Specification types
+ */
+// Layers
+import type {
+  BackgroundLayer,
+  SkyLayer,
+  CircleLayer,
+  FillLayer,
+  FillExtrusionLayer,
+  HeatmapLayer,
+  HillshadeLayer,
+  LineLayer,
+  RasterLayer,
+  SymbolLayer
+} from 'mapbox-gl';
+
+export type AnyLayer =
+  | BackgroundLayer
+  | CircleLayer
+  | FillExtrusionLayer
+  | FillLayer
+  | HeatmapLayer
+  | HillshadeLayer
+  | LineLayer
+  | RasterLayer
+  | SymbolLayer
+  | SkyLayer;
+
+export type {
+  BackgroundLayer,
+  SkyLayer,
+  CircleLayer,
+  FillLayer,
+  FillExtrusionLayer,
+  HeatmapLayer,
+  HillshadeLayer,
+  LineLayer,
+  RasterLayer,
+  SymbolLayer
+};
+
+// Sources
+import type {
+  GeoJSONSourceRaw as GeoJSONSource,
+  VideoSourceRaw as VideoSource,
+  ImageSourceRaw as ImageSource,
+  VectorSource,
+  RasterSource,
+  CanvasSourceRaw as CanvasSource,
+  RasterDemSource
+} from 'mapbox-gl';
+
+export type AnySource =
+  | GeoJSONSource
+  | VideoSource
+  | ImageSource
+  | CanvasSource
+  | VectorSource
+  | RasterSource
+  | RasterDemSource;
+
+export type {
+  GeoJSONSource,
+  VideoSource,
+  ImageSource,
+  CanvasSource,
+  VectorSource,
+  RasterSource,
+  RasterDemSource
+};
+
+// Other
+export type {
+  Style as MapboxStyle,
+  Light,
+  Fog,
+  TerrainSpecification as Terrain,
+  Projection
+} from 'mapbox-gl';

--- a/src/types/style-spec-maplibre.ts
+++ b/src/types/style-spec-maplibre.ts
@@ -1,10 +1,8 @@
 /*
- * Mapbox Style Specification types
- * Note that these are NOT base map specific - all compatible map libraries implement the same spec
+ * Maplibre Style Specification types
+ * Type names are aligned with mapbox
  */
 import type {
-  FilterSpecification,
-  PropertyValueSpecification,
   BackgroundLayerSpecification as BackgroundLayer,
   CircleLayerSpecification as CircleLayer,
   FillLayerSpecification as FillLayer,
@@ -35,32 +33,6 @@ export type {
   SymbolLayer
 };
 
-/**
- * @deprecated use `fog` instead
- */
-export type SkyLayer = {
-  id: string;
-  type: 'sky';
-  metadata?: unknown;
-  minzoom?: number;
-  maxzoom?: number;
-  filter?: FilterSpecification;
-  layout?: {
-    visibility?: 'visible' | 'none';
-  };
-  paint?: {
-    'sky-atmosphere-color'?: PropertyValueSpecification<string>;
-    'sky-atmosphere-halo-color'?: PropertyValueSpecification<string>;
-    'sky-atmosphere-sun'?: PropertyValueSpecification<number[]>;
-    'sky-atmosphere-sun-intensity'?: PropertyValueSpecification<number>;
-    'sky-gradient'?: PropertyValueSpecification<string>;
-    'sky-gradient-center'?: PropertyValueSpecification<number[]>;
-    'sky-gradient-radius'?: PropertyValueSpecification<number>;
-    'sky-opacity'?: PropertyValueSpecification<number>;
-    'sky-type'?: 'gradient' | 'atmosphere';
-  };
-};
-
 export type AnyLayer =
   | BackgroundLayer
   | CircleLayer
@@ -70,8 +42,7 @@ export type AnyLayer =
   | HillshadeLayer
   | LineLayer
   | RasterLayer
-  | SymbolLayer
-  | SkyLayer;
+  | SymbolLayer;
 
 // Sources
 export {GeoJSONSource, VideoSource, ImageSource, VectorSource, RasterSource, RasterDemSource};
@@ -102,26 +73,5 @@ export type {
 } from '@maplibre/maplibre-gl-style-spec';
 
 // The following types are not yet supported by maplibre
-export interface Fog {
-  color?: PropertyValueSpecification<string>;
-  'horizon-blend'?: PropertyValueSpecification<number>;
-  range?: PropertyValueSpecification<number[]>;
-}
-
-type ProjectionNames =
-  | 'albers'
-  | 'equalEarth'
-  | 'equirectangular'
-  | 'lambertConformalConic'
-  | 'mercator'
-  | 'naturalEarth'
-  | 'winkelTripel'
-  | 'globe';
-
-export type Projection =
-  | ProjectionNames
-  | {
-      name: ProjectionNames;
-      center?: [number, number];
-      parallels?: [number, number];
-    };
+export type Fog = never;
+export type Projection = never;

--- a/src/utils/style-utils.ts
+++ b/src/utils/style-utils.ts
@@ -1,4 +1,4 @@
-import {ImmutableLike, MapboxStyle} from '../types';
+import {ImmutableLike, MapStyle} from '../types';
 
 const refProps = ['type', 'source', 'source-layer', 'minzoom', 'maxzoom', 'filter', 'layout'];
 
@@ -6,8 +6,8 @@ const refProps = ['type', 'source', 'source-layer', 'minzoom', 'maxzoom', 'filte
 // If immutable - convert to plain object
 // Work around some issues in older styles that would fail Mapbox's diffing
 export function normalizeStyle(
-  style: string | MapboxStyle | ImmutableLike<MapboxStyle>
-): string | MapboxStyle {
+  style: string | MapStyle | ImmutableLike<MapStyle>
+): string | MapStyle {
   if (!style) {
     return null;
   }


### PR DESCRIPTION
To account for the divergence between Mapbox and Maplibre styles, this PR stops using `@maplibre/maplibre-gl-style-spec` for both endpoints. Style and event types are passed in as generics specific to each base map library.