### PR TITLE
fix: add missing exports for subpath module

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,28 @@
   "types": "dist/esm/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/es5/index.d.ts",
+        "default": "./dist/es5/index.js"
+      }
+    },
+    "./maplibre": {
+      "import": {
+        "types": "./dist/esm/exports-maplibre.d.ts",
+        "default": "./dist/esm/exports-maplibre.js"
+      },
+      "require": {
+        "types": "./dist/es5/exports-maplibre.d.ts",
+        "default": "./dist/es5/exports-maplibre.js"
+      }
+    }
+  },
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
Subpath exports should be defined via package.json exports field for ESM.

 - https://webpack.js.org/configuration/module/#resolvefullyspecified
 - https://www.typescriptlang.org/docs/handbook/esm-node.html
 - https://nodejs.org/api/packages.html#subpath-exports

It's still not ESM compliant, because inside CJS packages ESM modules should have extension `.mjs` and all their imports should be fully specified `import './events.mjs'`, not `import './events'`. 