### PR TITLE
Allow disabling RTLTextPlugin and load lazy

### DIFF
--- a/docs/api-reference/map.md
+++ b/docs/api-reference/map.md
@@ -536,13 +536,13 @@ If `reuseMaps` is set to `true`, when a map component is unmounted, the underlyi
 
 Note that since some map options cannot be modified after initialization, when reusing maps, only the reactive props and `initialViewState` of the new component are respected.
 
-#### `RTLTextPlugin`: string {#rtltextplugin}
+#### `RTLTextPlugin`: string | false {#rtltextplugin}
 
 Default: `'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js'`
 
 Sets the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text). Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.
 
-Setting this prop is the equivelant of calling [mapboxgl.setRTLTextPlugin](https://docs.mapbox.com/mapbox-gl-js/api/properties/#setrtltextplugin) with `lazy: true`.
+Setting this prop is the equivalent of calling [mapboxgl.setRTLTextPlugin](https://docs.mapbox.com/mapbox-gl-js/api/properties/#setrtltextplugin) with `lazy: true`. Set to `false` to disable loading the RTL text plugin.
 
 #### `workerClass`: object {#workerclass}
 

--- a/src/utils/set-globals.ts
+++ b/src/utils/set-globals.ts
@@ -6,7 +6,7 @@ export type GlobalSettings = {
    */
   maxParallelImageRequests?: number;
   /** The map's RTL text plugin. Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.  */
-  RTLTextPlugin?: string;
+  RTLTextPlugin?: string | false;
   /** Provides an interface for external module bundlers such as Webpack or Rollup to package mapbox-gl's WebWorker into a separate class and integrate it with the library.
 Takes precedence over `workerUrl`. */
   workerClass?: any;

--- a/src/utils/set-globals.ts
+++ b/src/utils/set-globals.ts
@@ -51,7 +51,7 @@ export default function setGlobals(mapLib: any, props: GlobalSettings) {
           console.error(error);
         }
       },
-      false
+      true
     );
   }
 }


### PR DESCRIPTION
As discussed in #2310 this is the patch which fixes the following for the `RTLTextPlugin` prop:

1. Load lazy
2. Allow the prop to be set to `false` to disable the current default load