### PR TITLE
Update Demo in README to show importing mapbox styles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ npm install --save react-map-gl mapbox-gl
 import * as React from 'react';
 import Map from 'react-map-gl';
 
+// MapBox styles
+import "mapbox-gl/dist/mapbox-gl.css";
+
 function App() {
   return <Map
     mapLib={import('mapbox-gl')}


### PR DESCRIPTION
The readme demo does not import the mapbox styles, which causes CSS errors like the mentioned issue.

Closes #2216 