### PR TITLE
Docs: Fix maplibre link on attribution-control.md

### DIFF
--- a/docs/api-reference/attribution-control.md
+++ b/docs/api-reference/attribution-control.md
@@ -68,7 +68,7 @@ CSS style override that applies to the control's container.
 
 The properties in this section are not reactive. They are only used when the component first mounts.
 
-Any options supported by the `AttributionControl` class ([Mapbox](https://docs.mapbox.com/mapbox-gl-js/api/markers/#attributioncontrol) | [Maplibre](https://maplibre.org/maplibre-gl-js-docs/api/markers/#attributioncontrol)), such as
+Any options supported by the `AttributionControl` class ([Mapbox](https://docs.mapbox.com/mapbox-gl-js/api/markers/#attributioncontrol) | [Maplibre](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.AttributionControl/)), such as
 
 - `compact`
 - `customAttribution`


### PR DESCRIPTION
This is the right deep like. Ideally, we would also link to https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.AttributionOptions/ which goes into details on the options. But the top level link might have to be enough…?