### PR TITLE
Add getCanvasContainer to types

### DIFF
--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -77,6 +77,8 @@ export interface MapInstance extends Evented {
 
   getCanvas(): HTMLCanvasElement;
 
+  getCanvasContainer(): HTMLElement;
+
   remove(): void;
 
   triggerRepaint(): void;
@@ -170,7 +172,7 @@ export interface ScaleControlInstance extends IControl {
 /**
  * A user-facing type that represents the minimal intersection between Mapbox and Maplibre
  * User provided `mapLib` is supposed to implement this interface
- * Only losely typed for compatibility
+ * Only loosely typed for compatibility
  */
 export interface MapLib<MapT extends MapInstance> {
   supported?: (options: any) => boolean;


### PR DESCRIPTION
Both MapLibre GL and Mapbox GL have a function 'getCanvasContainer':

- https://github.com/mapbox/mapbox-gl-js/blob/bb51e3ba7cceef993628f6c85eef69435d902e4c/src/ui/map.js#L788
- https://github.com/maplibre/maplibre-gl-js/blob/3bea9a10acf741caf0913eb3792ef0a268f6fbe3/src/ui/map.ts#L2837

I would like to suggest that it be added to the types if possible. The attached is a simple pull request adding this type.

Thanks!