### PR TITLE
Fix changing zoom and center at once

### DIFF
--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -57,16 +57,16 @@ export function applyViewStateToTransform(tr: Transform, props: MapboxProps): bo
   const v: Partial<ViewState> = props.viewState || props;
   let changed = false;
 
+  if ('zoom' in v) {
+    const zoom = tr.zoom;
+    tr.zoom = v.zoom;
+    changed = changed || zoom !== tr.zoom;
+  }
   if ('longitude' in v && 'latitude' in v) {
     const center = tr.center;
     // @ts-ignore
     tr.center = new center.constructor(v.longitude, v.latitude);
     changed = changed || center !== tr.center;
-  }
-  if ('zoom' in v) {
-    const zoom = tr.zoom;
-    tr.zoom = v.zoom;
-    changed = changed || zoom !== tr.zoom;
   }
   if ('bearing' in v) {
     const bearing = tr.bearing;


### PR DESCRIPTION
## What this does

Previously, if you wanted to zoom in and pan the map in the same viewport operation when you were very zoomed out, it would get "stuck" at latitudes near the equator.

If you're zoomed right out such that the equator is at the center of your viewport, and want to zoom in to a point at a much higher zoom level away from the equator, because the center change is handled first, the center change is constrained, so the latitude doesn't change. Then the zoom happens, and you end up at the wrong place.

By changing the order to zoom first, we ensure that the constraining that happens during the center change happens with the correct available center range.

## Testing

The unit tests still pass, but it's hard to exercise the exact scenario here because it's dependent on the viewport constraining behaviour which is mocked out in this repo.