### PR TITLE
Update fullscreen-control source code link

### DIFF
--- a/docs/api-reference/fullscreen-control.md
+++ b/docs/api-reference/fullscreen-control.md
@@ -78,4 +78,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[fullscreen-control.ts](https://github.com/visgl/react-map-gl/blob/7.1-release/src/components/fullscreen-control.tsx)
+[fullscreen-control.ts](https://github.com/visgl/react-map-gl/tree/7.1-release/src/components/fullscreen-control.tsx)

--- a/docs/api-reference/fullscreen-control.md
+++ b/docs/api-reference/fullscreen-control.md
@@ -78,4 +78,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[fullscreen-control.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/fullscreen-control.ts)
+[fullscreen-control.ts](https://github.com/visgl/react-map-gl/blob/7.1-release/src/components/fullscreen-control.tsx)


### PR DESCRIPTION
It appears that the link to the source code of `fullscreen-control` was updated to have `.tsx` extension instead of `.ts` currently the live will break 