### PR TITLE
fix(meta): Put 'types' first in package.json#exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
   "module": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.js"
     },
     "./maplibre": {
-      "import": "./dist/exports-maplibre.js",
+      "types": "./dist/exports-maplibre.d.ts",
       "require": "./dist/exports-maplibre.cjs",
-      "types": "./dist/exports-maplibre.d.ts"
+      "import": "./dist/exports-maplibre.js"
     }
   },
   "files": [


### PR DESCRIPTION
I'm not aware that anything is broken without this, but the TS documentation mentions that the 'types' entrypoint should be first in `package.json#exports`, and this matches deckgl and lumagl's configuration.

https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/