### PR TITLE
chore(ci): Update to Node.js v22 in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
         run: git fetch --tags -f
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '22.x'
 
       - name: Publish release
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v2.1.1
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '22.x'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v2.1.1
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '22.x'
 
       - name: Get version
         id: get-version


### PR DESCRIPTION
PR #2369 fails in CI with error — 

> error puppeteer-core@22.6.3: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"
error Found incompatible module.

This PR attempts to upgrade to Node v22, but if CI still fails I'll try downgrading to v20 or v18.