### PR TITLE
Docs: Add TS types to initialViewState docs

### DIFF
--- a/docs/api-reference/map.md
+++ b/docs/api-reference/map.md
@@ -119,7 +119,7 @@ If `undefined` is provided, removes terrain from the map.
 
 ### Camera options
 
-#### `initialViewState`: object {#initialviewstate}
+#### `initialViewState`: object (`MapProps['initialViewState']`) {#initialviewstate}
 
 The initial view state of the map. If specified, `longitude`, `latitude`, `zoom` etc. in props are ignored when constructing the map. Only specify `initialViewState` if `Map` is being used as an **uncontrolled component**. See [state management](../get-started/state-management.md) for examples.
 


### PR DESCRIPTION
The types for `initialViewState` are a bit hard to find but can be pulled from https://github.com/visgl/react-map-gl/blob/master/src/mapbox/mapbox.ts#L38-L48. This change adds them to the docs explicitly.