### PR TITLE
chore: CI workflow improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,19 @@ jobs:
 
     if: github.repository_owner == 'visgl'
 
+    permissions:
+      contents: write
+
     env:
-      ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2.1.1
 
-      - name: Get git tags (https://github.com/actions/checkout/issues/206)
-        run: git fetch --tags -f
-
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       - name: Publish release
         run: |
@@ -33,4 +33,4 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/visgl/react-map-gl/releases \
             -d "${body}" \
-            -H "Authorization: token ${ADMIN_TOKEN}"
+            -H "Authorization: token ${GITHUB_TOKEN}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: '18.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,26 +11,25 @@ jobs:
   test-node:
     runs-on: ubuntu-latest
 
-    env:
-      VITE_MAPBOX_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN_CI }}
-
     steps:
-      - uses: actions/checkout@v2.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       - name: Install dependencies
         run: |
           yarn bootstrap
 
       - name: Run tests
+        env:
+          VITE_MAPBOX_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN_CI }}
         run: |
           yarn test ci
 
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@09b709cf6a16e30b0808ba050c7a6e8a5ef13f8d # v1.2.5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -6,44 +6,48 @@ on:
       - '*-release'
 
 jobs:
-  publish-website:
+  check_branch:
     runs-on: ubuntu-latest
-
-    if: github.repository_owner == 'visgl'
-
-    env:
-      MapboxAccessToken: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+    outputs:
+      should_deploy: ${{ endsWith(github.ref, steps.get_version.outputs.latest) }}
 
     steps:
-      - uses: actions/checkout@v2.1.1
-
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '16.x'
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Get version
-        id: get-version
-        run: LATEST=$(npm show react-map-gl version | grep -o -E "^[0-9]+\.[0-9]+") && echo "::set-output name=latest::/${LATEST}-release"
-
-      - name: Check version
-        if: ${{ !endsWith(github.ref, steps.get-version.outputs.latest) }}
+        id: get_version
         run: |
-          echo "Website is only published from the latest release branch"
+          LATEST=$(npm show react-map-gl version | grep -o -E "^[0-9]+\.[0-9]+")
+          echo "latest=${LATEST}-release" >> "$GITHUB_OUTPUT"
 
-      - name: Build website
-        if: ${{ endsWith(github.ref, steps.get-version.outputs.latest) }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: check_branch
+
+    if: ${{ github.repository_owner == 'visgl' && needs.check_branch.outputs.should_deploy }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Use Node.js
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
         run: |
           yarn bootstrap
-          cd website
-          yarn
-          yarn build
+          (cd website && yarn)
+
+      - name: Build website
+        env:
+          MapboxAccessToken: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+        run: (cd website && yarn build)
 
       - name: Deploy
-        if: ${{ endsWith(github.ref, steps.get-version.outputs.latest) }}
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505 # 3.7.1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
           BRANCH: gh-pages
           FOLDER: website/build
           CLEAN: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -23,11 +23,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: check_branch
+    
+    permissions:
+      contents: write
 
     if: ${{ github.repository_owner == 'visgl' && needs.check_branch.outputs.should_deploy }}
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
 
       - name: Use Node.js
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
@@ -47,7 +52,7 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505 # 3.7.1
         with:
-          GITHUB_TOKEN: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: website/build
           CLEAN: true

--- a/scripts/github-release.js
+++ b/scripts/github-release.js
@@ -28,7 +28,7 @@ console.log(JSON.stringify(requestBody));
 
 function getGitTag() {
   try {
-    return execSync('git describe --exact-match HEAD', {
+    return execSync('git describe --tags --exact-match HEAD', {
       stdio: [null, 'pipe', null],
       encoding: 'utf-8'
     }).trim();


### PR DESCRIPTION
- Use Node 18
- Use access token with stricter scope
- Explicit hash for external tasks
- Handles unannotated git tag in the CI context
