### PR TITLE
fix: change transformation setters call order

### DIFF
--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -57,12 +57,6 @@ export function applyViewStateToTransform(tr: Transform, props: MapboxProps): bo
   const v: Partial<ViewState> = props.viewState || props;
   let changed = false;
 
-  if ('longitude' in v && 'latitude' in v) {
-    const center = tr.center;
-    // @ts-ignore
-    tr.center = new center.constructor(v.longitude, v.latitude);
-    changed = changed || center !== tr.center;
-  }
   if ('zoom' in v) {
     const zoom = tr.zoom;
     tr.zoom = v.zoom;
@@ -81,6 +75,12 @@ export function applyViewStateToTransform(tr: Transform, props: MapboxProps): bo
   if (v.padding && !tr.isPaddingEqual(v.padding)) {
     changed = true;
     tr.padding = v.padding;
+  }
+  if ('longitude' in v && 'latitude' in v) {
+    const center = tr.center;
+    // @ts-ignore
+    tr.center = new center.constructor(v.longitude, v.latitude);
+    changed = changed || center !== tr.center;
   }
   return changed;
 }

--- a/test/src/utils/transform.spec.js
+++ b/test/src/utils/transform.spec.js
@@ -90,5 +90,11 @@ test('applyViewStateToTransform', t => {
   changed = applyViewStateToTransform(tr, {viewState: {pitch: 30}});
   t.notOk(changed, 'nothing changed');
 
+  applyViewStateToTransform(tr, {longitude: 0, latitude: 0, zoom: 0});
+  changed = applyViewStateToTransform(tr, {longitude: 12, latitude: 34, zoom: 15});
+  t.ok(changed, 'center and zoom changed');
+  t.equal(tr.zoom, 15, 'zoom is correct');
+  t.equal(tr.center.lat, 34, 'center latitude is correct');
+
   t.end();
 });


### PR DESCRIPTION
The order of setters in `applyViewStateToTransform` has a side effect which leads to wrong camera transformation. In a case of `map.jumpTo({center: [12,34], zoom: 15})` from `{center: [0,0], zoom: 0}` the current order of setters in case of maplibre-gl leads to the following:

```
tr.center = new center.constructor(v.longitude, v.latitude);  /* (12, 34); */
  -> const {center, zoom} = this.getConstrained(this.center /* [12, 34]*/ , this.zoom /* 0 */);
       this.center = center;  /* [12, 0] */
       this.zoom = zoom;  /* 0 */

tr.zoom = v.zoom; /* 15 */
  -> const {center, zoom} = this.getConstrained(this.center /* [12, 0]*/ , this.zoom /* 15 */);
       this.center = center;  /* [12, 0] */
       this.zoom = zoom;  /* 15 */
```

But expected would be to have `{center: [12,34], zoom: 15}` instead of `{center: [12,0], zoom: 15}`.

The changed order leads to the following setters sequence
```
tr.zoom = v.zoom; /* 15 */
  -> const {center, zoom} = this.getConstrained(this.center /* [0, 0]*/ , this.zoom /* 15 */);
       this.center = center;  /* [0, 0] */
       this.zoom = zoom;  /* 15 */

tr.center = new center.constructor(v.longitude, v.latitude);  /* (12, 34); */
  -> const {center, zoom} = this.getConstrained(this.center /* [12, 34]*/ , this.zoom /* 15 */);
       this.center = center;  /* [12, 34] */
       this.zoom = zoom;  /* 15 */
```
