### PR TITLE
Update map.md

### DIFF
--- a/docs/api-reference/map.md
+++ b/docs/api-reference/map.md
@@ -577,7 +577,7 @@ import Map from 'react-map-gl';
 import type {MapRef} from 'react-map-gl';
 
 function App() {
-  const mapRef = useRef<MapRef>();
+  const mapRef = useRef<MapRef>(null);
 
   const onMapLoad = useCallback(() => {
     mapRef.current.on('move', () => {


### PR DESCRIPTION
Changing the definition of the mapRef to have initial value of null. Otherwise useRef returns a MutableRefObject, as opposed to a RefObject, which cannot be assigned to the map's ref property.