### PR TITLE
Fix text wrap issue for mobile devices in React Map GL

### DIFF
--- a/website/src/components/home/styled.js
+++ b/website/src/components/home/styled.js
@@ -53,6 +53,7 @@ export const ProjectName = styled.h1`
   font-weight: 700;
   margin: 0;
   margin-bottom: 16px;
+  word-wrap: normal;
 `;
 
 export const GetStartedLink = styled.a`


### PR DESCRIPTION
Closes #2419

This PR fixes the text wrapping issue on mobile devices like Samsung Galaxy S8+ 
by setting `word-wrap: normal` for the title element. This ensures proper rendering
of "React Map GL" without breaking the word "React".
