### PR TITLE
feat: remove `RTLTextPlugin` default for MapLibre

### DIFF
--- a/docs/api-reference/maplibre/map.md
+++ b/docs/api-reference/maplibre/map.md
@@ -493,14 +493,12 @@ If `reuseMaps` is set to `true`, when a map component is unmounted, the underlyi
 
 Note that since some map options cannot be modified after initialization, when reusing maps, only the reactive props and `initialViewState` of the new component are respected.
 
-#### `RTLTextPlugin`: string | false {#rtltextplugin}
+#### `RTLTextPlugin`: object {#rtltextplugin}
 
-Default: `'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js'`
+- `pluginUrl`: `string` URL to the plugin JS file.
+- `lazy`: `boolean` When true, the plugin is only loaded when the map first encounters Hebrew or Arabic text. Default `true`.
 
-Sets the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text). Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.
-
-Setting this prop is the equivalent of calling [setRTLTextPlugin](https://maplibre.org/maplibre-gl-js/docs/API/functions/setRTLTextPlugin/) with `lazy: true`. Set to `false` to disable loading the RTL text plugin.
-
+Sets the map's RTL text plugin via [setRTLTextPlugin](https://maplibre.org/maplibre-gl-js/docs/API/functions/setRTLTextPlugin/). Can be used with [mapbox-gl-rtl-text](https://github.com/mapbox/mapbox-gl-rtl-text). Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.
 
 #### `workerCount`: number {#workercount}
 

--- a/docs/api-reference/maplibre/map.md
+++ b/docs/api-reference/maplibre/map.md
@@ -493,7 +493,7 @@ If `reuseMaps` is set to `true`, when a map component is unmounted, the underlyi
 
 Note that since some map options cannot be modified after initialization, when reusing maps, only the reactive props and `initialViewState` of the new component are respected.
 
-#### `RTLTextPlugin`: object {#rtltextplugin}
+#### `RTLTextPlugin`: string | object {#rtltextplugin}
 
 - `pluginUrl`: `string` URL to the plugin JS file.
 - `lazy`: `boolean` When true, the plugin is only loaded when the map first encounters Hebrew or Arabic text. Default `true`.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -22,7 +22,7 @@
 
 #### Removed default for `RTLTextPlugin`
 
-The default `RTLTextPlugin` loaded from mapbox.com has been removed for MapBox.
+The default `RTLTextPlugin` loaded from mapbox.com has been removed to align with the default behavior of MapLibre.
 To keep the previous behavior, specify the `pluginUrl` which was previously used or supply the plugin from any other source:
 
 ```tsx

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -26,12 +26,7 @@ The default `RTLTextPlugin` loaded from mapbox.com has been removed to align wit
 To keep the previous behavior, specify the `pluginUrl` which was previously used or supply the plugin from any other source:
 
 ```tsx
-<Map
-  RTLTextPlugin={{
-    pluginUrl:
-      'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js'
-  }}
-/>
+<Map RTLTextPlugin="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js" />
 ```
 
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -18,6 +18,22 @@
   | `*Layer` | `*LayerSpecification` |
   | `*SourceRaw` | `*SourceSpecification` |
 
+### MapLibre
+
+#### Removed default for `RTLTextPlugin`
+
+The default `RTLTextPlugin` loaded from mapbox.com has been removed for MapBox.
+To keep the previous behavior, specify the `pluginUrl` which was previously used or supply the plugin from any other source:
+
+```tsx
+<Map
+  RTLTextPlugin={{
+    pluginUrl:
+      'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js'
+  }}
+/>
+```
+
 
 ## Upgrading to v7.1
 

--- a/modules/react-maplibre/src/utils/set-globals.ts
+++ b/modules/react-maplibre/src/utils/set-globals.ts
@@ -4,7 +4,7 @@ export type GlobalSettings = {
    */
   maxParallelImageRequests?: number;
   /** The map's RTL text plugin. Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.  */
-  RTLTextPlugin?: string | false;
+  RTLTextPlugin?: {pluginUrl: string; lazy?: boolean};
   /** The number of web workers instantiated on a page with maplibre-gl maps.
    * @default 2
    */
@@ -16,26 +16,21 @@ export type GlobalSettings = {
 };
 
 export default function setGlobals(mapLib: any, props: GlobalSettings) {
-  const {
-    RTLTextPlugin = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js',
-    maxParallelImageRequests,
-    workerCount,
-    workerUrl
-  } = props;
+  const {RTLTextPlugin, maxParallelImageRequests, workerCount, workerUrl} = props;
   if (
     RTLTextPlugin &&
     mapLib.getRTLTextPluginStatus &&
     mapLib.getRTLTextPluginStatus() === 'unavailable'
   ) {
     mapLib.setRTLTextPlugin(
-      RTLTextPlugin,
+      RTLTextPlugin.pluginUrl,
       (error?: Error) => {
         if (error) {
           // eslint-disable-next-line
           console.error(error);
         }
       },
-      true
+      RTLTextPlugin.lazy ?? true
     );
   }
   if (maxParallelImageRequests !== undefined) {

--- a/modules/react-maplibre/src/utils/set-globals.ts
+++ b/modules/react-maplibre/src/utils/set-globals.ts
@@ -4,7 +4,7 @@ export type GlobalSettings = {
    */
   maxParallelImageRequests?: number;
   /** The map's RTL text plugin. Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.  */
-  RTLTextPlugin?: {pluginUrl: string; lazy?: boolean};
+  RTLTextPlugin?: string | {pluginUrl: string; lazy?: boolean};
   /** The number of web workers instantiated on a page with maplibre-gl maps.
    * @default 2
    */
@@ -22,15 +22,18 @@ export default function setGlobals(mapLib: any, props: GlobalSettings) {
     mapLib.getRTLTextPluginStatus &&
     mapLib.getRTLTextPluginStatus() === 'unavailable'
   ) {
+    const {pluginUrl, lazy = true} =
+      typeof RTLTextPlugin === 'string' ? {pluginUrl: RTLTextPlugin} : RTLTextPlugin;
+
     mapLib.setRTLTextPlugin(
-      RTLTextPlugin.pluginUrl,
+      pluginUrl,
       (error?: Error) => {
         if (error) {
           // eslint-disable-next-line
           console.error(error);
         }
       },
-      RTLTextPlugin.lazy ?? true
+      lazy
     );
   }
   if (maxParallelImageRequests !== undefined) {


### PR DESCRIPTION
As discussed previously, I've removed the default value for the `RTLTextPlugin` which loaded from mapbox.com. This aligns more closely to the default behavior of the maplib, forcing the user to manually set such url. The prop now also accepts an object, to allow full configuration of the `setRTLTextPlugin` call.

This implements the proper fix towards https://github.com/visgl/react-map-gl/issues/2310

BREAKING CHANGE: `RTLTextPlugin` must now be set manually as prop