### PR TITLE
Handle class name change

### DIFF
--- a/modules/react-mapbox/src/components/marker.ts
+++ b/modules/react-mapbox/src/components/marker.ts
@@ -9,6 +9,7 @@ import type {MarkerEvent, MarkerDragEvent} from '../types/events';
 
 import {MapContext} from './map';
 import {arePointsEqual} from '../utils/deep-equal';
+import {compareClassNames} from '../utils/compare-class-names';
 
 export type MarkerProps = MarkerOptions & {
   /** Longitude of the anchor location */
@@ -32,7 +33,6 @@ export const Marker = memo(
   forwardRef((props: MarkerProps, ref: React.Ref<MarkerInstance>) => {
     const {map, mapLib} = useContext(MapContext);
     const thisRef = useRef({props});
-    thisRef.current.props = props;
 
     const marker: MarkerInstance = useMemo(() => {
       let hasChildren = false;
@@ -102,6 +102,7 @@ export const Marker = memo(
 
     useImperativeHandle(ref, () => marker, []);
 
+    const oldProps = thisRef.current.props;
     if (marker.getLngLat().lng !== longitude || marker.getLngLat().lat !== latitude) {
       marker.setLngLat([longitude, latitude]);
     }
@@ -123,7 +124,17 @@ export const Marker = memo(
     if (marker.getPopup() !== popup) {
       marker.setPopup(popup);
     }
+    const classNameDiff = compareClassNames(oldProps.className, props.className);
+    if (classNameDiff) {
+      for (const c of classNameDiff[0]) {
+        marker.addClassName(c);
+      }
+      for (const c of classNameDiff[1]) {
+        marker.removeClassName(c);
+      }
+    }
 
+    thisRef.current.props = props;
     return createPortal(props.children, marker.getElement());
   })
 );

--- a/modules/react-mapbox/src/components/marker.ts
+++ b/modules/react-mapbox/src/components/marker.ts
@@ -126,11 +126,8 @@ export const Marker = memo(
     }
     const classNameDiff = compareClassNames(oldProps.className, props.className);
     if (classNameDiff) {
-      for (const c of classNameDiff[0]) {
-        marker.addClassName(c);
-      }
-      for (const c of classNameDiff[1]) {
-        marker.removeClassName(c);
+      for (const c of classNameDiff) {
+        marker.toggleClassName(c);
       }
     }
 

--- a/modules/react-mapbox/src/components/popup.ts
+++ b/modules/react-mapbox/src/components/popup.ts
@@ -75,6 +75,7 @@ export const Popup = memo(
         popup.setLngLat([props.longitude, props.latitude]);
       }
       if (props.offset && !deepEqual(oldProps.offset, props.offset)) {
+        popup.options.anchor = props.anchor;
         popup.setOffset(props.offset);
       }
       if (oldProps.anchor !== props.anchor || oldProps.maxWidth !== props.maxWidth) {
@@ -82,11 +83,8 @@ export const Popup = memo(
       }
       const classNameDiff = compareClassNames(oldProps.className, props.className);
       if (classNameDiff) {
-        for (const c of classNameDiff[0]) {
-          popup.addClassName(c);
-        }
-        for (const c of classNameDiff[1]) {
-          popup.removeClassName(c);
+        for (const c of classNameDiff) {
+          popup.toggleClassName(c);
         }
       }
       thisRef.current.props = props;

--- a/modules/react-mapbox/src/components/popup.ts
+++ b/modules/react-mapbox/src/components/popup.ts
@@ -9,6 +9,7 @@ import type {PopupEvent} from '../types/events';
 
 import {MapContext} from './map';
 import {deepEqual} from '../utils/deep-equal';
+import {compareClassNames} from '../utils/compare-class-names';
 
 export type PopupProps = PopupOptions & {
   /** Longitude of the anchor location */
@@ -24,11 +25,6 @@ export type PopupProps = PopupOptions & {
   children?: React.ReactNode;
 };
 
-// Adapted from https://github.com/mapbox/mapbox-gl-js/blob/v1.13.0/src/ui/popup.js
-function getClassList(className: string) {
-  return new Set(className ? className.trim().split(/\s+/) : []);
-}
-
 /* eslint-disable complexity,max-statements */
 export const Popup = memo(
   forwardRef((props: PopupProps, ref: React.Ref<PopupInstance>) => {
@@ -37,7 +33,6 @@ export const Popup = memo(
       return document.createElement('div');
     }, []);
     const thisRef = useRef({props});
-    thisRef.current.props = props;
 
     const popup: PopupInstance = useMemo(() => {
       const options = {...props};
@@ -75,32 +70,26 @@ export const Popup = memo(
     useImperativeHandle(ref, () => popup, []);
 
     if (popup.isOpen()) {
+      const oldProps = thisRef.current.props;
       if (popup.getLngLat().lng !== props.longitude || popup.getLngLat().lat !== props.latitude) {
         popup.setLngLat([props.longitude, props.latitude]);
       }
-      if (props.offset && !deepEqual(popup.options.offset, props.offset)) {
+      if (props.offset && !deepEqual(oldProps.offset, props.offset)) {
         popup.setOffset(props.offset);
       }
-      if (popup.options.anchor !== props.anchor || popup.options.maxWidth !== props.maxWidth) {
-        popup.options.anchor = props.anchor;
+      if (oldProps.anchor !== props.anchor || oldProps.maxWidth !== props.maxWidth) {
         popup.setMaxWidth(props.maxWidth);
       }
-      if (popup.options.className !== props.className) {
-        const prevClassList = getClassList(popup.options.className);
-        const nextClassList = getClassList(props.className);
-
-        for (const c of prevClassList) {
-          if (!nextClassList.has(c)) {
-            popup.removeClassName(c);
-          }
+      const classNameDiff = compareClassNames(oldProps.className, props.className);
+      if (classNameDiff) {
+        for (const c of classNameDiff[0]) {
+          popup.addClassName(c);
         }
-        for (const c of nextClassList) {
-          if (!prevClassList.has(c)) {
-            popup.addClassName(c);
-          }
+        for (const c of classNameDiff[1]) {
+          popup.removeClassName(c);
         }
-        popup.options.className = props.className;
       }
+      thisRef.current.props = props;
     }
 
     return createPortal(props.children, container);

--- a/modules/react-mapbox/src/utils/compare-class-names.ts
+++ b/modules/react-mapbox/src/utils/compare-class-names.ts
@@ -1,0 +1,36 @@
+/** Compare two classNames string and return the difference */
+export function compareClassNames(
+  prevClassName: string | undefined,
+  nextClassName: string | undefined
+): [added: string[], removed: string[]] | null {
+  if (prevClassName === nextClassName) {
+    return null;
+  }
+
+  const prevClassList = getClassList(prevClassName);
+  const nextClassList = getClassList(nextClassName);
+  const added: string[] = [];
+  const removed: string[] = [];
+
+  for (const c of prevClassList) {
+    if (!nextClassList.has(c)) {
+      removed.push(c);
+    }
+  }
+
+  if (removed.length === 0 && prevClassList.size === nextClassList.size) {
+    return null;
+  }
+
+  for (const c of nextClassList) {
+    if (!prevClassList.has(c)) {
+      added.push(c);
+    }
+  }
+
+  return [added, removed];
+}
+
+function getClassList(className: string | undefined) {
+  return new Set(className ? className.trim().split(/\s+/) : []);
+}

--- a/modules/react-mapbox/src/utils/compare-class-names.ts
+++ b/modules/react-mapbox/src/utils/compare-class-names.ts
@@ -2,33 +2,26 @@
 export function compareClassNames(
   prevClassName: string | undefined,
   nextClassName: string | undefined
-): [added: string[], removed: string[]] | null {
+): string[] | null {
   if (prevClassName === nextClassName) {
     return null;
   }
 
   const prevClassList = getClassList(prevClassName);
   const nextClassList = getClassList(nextClassName);
-  const added: string[] = [];
-  const removed: string[] = [];
-
-  for (const c of prevClassList) {
-    if (!nextClassList.has(c)) {
-      removed.push(c);
-    }
-  }
-
-  if (removed.length === 0 && prevClassList.size === nextClassList.size) {
-    return null;
-  }
+  const diff: string[] = [];
 
   for (const c of nextClassList) {
     if (!prevClassList.has(c)) {
-      added.push(c);
+      diff.push(c);
     }
   }
-
-  return [added, removed];
+  for (const c of prevClassList) {
+    if (!nextClassList.has(c)) {
+      diff.push(c);
+    }
+  }
+  return diff.length === 0 ? null : diff;
 }
 
 function getClassList(className: string | undefined) {

--- a/modules/react-mapbox/test/components/marker.spec.jsx
+++ b/modules/react-mapbox/test/components/marker.spec.jsx
@@ -49,6 +49,7 @@ test('Marker', async t => {
         offset={[0, 1]}
         rotation={30}
         draggable
+        className="classA"
         pitchAlignment="map"
         rotationAlignment="map"
         onDragStart={() => (callbackType = 'dragstart')}
@@ -64,6 +65,7 @@ test('Marker', async t => {
   t.not(rotation, marker.getRotation(), 'rotation is updated');
   t.not(pitchAlignment, marker.getPitchAlignment(), 'pitchAlignment is updated');
   t.not(rotationAlignment, marker.getRotationAlignment(), 'rotationAlignment is updated');
+  t.ok(marker._element.classList.contains('classA'), 'className is updated');
 
   marker.fire('dragstart');
   t.is(callbackType, 'dragstart', 'onDragStart called');

--- a/modules/react-mapbox/test/components/popup.spec.jsx
+++ b/modules/react-mapbox/test/components/popup.spec.jsx
@@ -67,8 +67,7 @@ test('Popup', async t => {
     </Map>
   );
   await sleep(1);
-
-  t.is(popup.options.className, 'classA', 'className is updated');
+  t.ok(popup._container.classList.contains('classA'), 'className is updated');
 
   root.unmount();
   t.end();

--- a/modules/react-mapbox/test/utils/compare-class-names.spec.js
+++ b/modules/react-mapbox/test/utils/compare-class-names.spec.js
@@ -1,0 +1,52 @@
+import test from 'tape-promise/tape';
+import {compareClassNames} from '@vis.gl/react-mapbox/utils/compare-class-names';
+
+test('compareClassNames', t => {
+  const TEST_CASES = [
+    {
+      title: 'Empty class names',
+      prevClassName: '',
+      nextClassName: '',
+      output: null
+    },
+    {
+      title: 'Identical class names',
+      prevClassName: 'marker active',
+      nextClassName: 'active  marker ',
+      output: null
+    },
+    {
+      title: 'Addition',
+      prevClassName: undefined,
+      nextClassName: 'marker',
+      output: [['marker'], []]
+    },
+    {
+      title: 'Addition',
+      prevClassName: 'marker',
+      nextClassName: 'marker active',
+      output: [['active'], []]
+    },
+    {
+      title: 'Removal',
+      prevClassName: 'marker active',
+      nextClassName: 'marker',
+      output: [[], ['active']]
+    },
+    {
+      title: 'Multiple addition & removal',
+      prevClassName: 'marker active',
+      nextClassName: 'marker hovered hidden',
+      output: [['hovered', 'hidden'], ['active']]
+    }
+  ];
+
+  for (const testCase of TEST_CASES) {
+    t.deepEqual(
+      compareClassNames(testCase.prevClassName, testCase.nextClassName),
+      testCase.output,
+      testCase.title
+    );
+  }
+  t.end();
+});

--- a/modules/react-mapbox/test/utils/compare-class-names.spec.js
+++ b/modules/react-mapbox/test/utils/compare-class-names.spec.js
@@ -19,25 +19,25 @@ test('compareClassNames', t => {
       title: 'Addition',
       prevClassName: undefined,
       nextClassName: 'marker',
-      output: [['marker'], []]
+      output: ['marker']
     },
     {
       title: 'Addition',
       prevClassName: 'marker',
       nextClassName: 'marker active',
-      output: [['active'], []]
+      output: ['active']
     },
     {
       title: 'Removal',
       prevClassName: 'marker active',
       nextClassName: 'marker',
-      output: [[], ['active']]
+      output: ['active']
     },
     {
       title: 'Multiple addition & removal',
       prevClassName: 'marker active',
       nextClassName: 'marker hovered hidden',
-      output: [['hovered', 'hidden'], ['active']]
+      output: ['hovered', 'hidden', 'active']
     }
   ];
 

--- a/modules/react-mapbox/test/utils/index.js
+++ b/modules/react-mapbox/test/utils/index.js
@@ -2,3 +2,4 @@ import './deep-equal.spec';
 import './transform.spec';
 import './style-utils.spec';
 import './apply-react-style.spec';
+import './compare-class-names.spec';

--- a/modules/react-maplibre/src/components/marker.ts
+++ b/modules/react-maplibre/src/components/marker.ts
@@ -9,6 +9,7 @@ import type {MarkerEvent, MarkerDragEvent} from '../types/events';
 
 import {MapContext} from './map';
 import {arePointsEqual} from '../utils/deep-equal';
+import {compareClassNames} from '../utils/compare-class-names';
 
 export type MarkerProps = MarkerOptions & {
   /** Longitude of the anchor location */
@@ -32,7 +33,6 @@ export const Marker = memo(
   forwardRef((props: MarkerProps, ref: React.Ref<MarkerInstance>) => {
     const {map, mapLib} = useContext(MapContext);
     const thisRef = useRef({props});
-    thisRef.current.props = props;
 
     const marker: MarkerInstance = useMemo(() => {
       let hasChildren = false;
@@ -102,6 +102,7 @@ export const Marker = memo(
 
     useImperativeHandle(ref, () => marker, []);
 
+    const oldProps = thisRef.current.props;
     if (marker.getLngLat().lng !== longitude || marker.getLngLat().lat !== latitude) {
       marker.setLngLat([longitude, latitude]);
     }
@@ -123,7 +124,17 @@ export const Marker = memo(
     if (marker.getPopup() !== popup) {
       marker.setPopup(popup);
     }
+    const classNameDiff = compareClassNames(oldProps.className, props.className);
+    if (classNameDiff) {
+      for (const c of classNameDiff[0]) {
+        marker.addClassName(c);
+      }
+      for (const c of classNameDiff[1]) {
+        marker.removeClassName(c);
+      }
+    }
 
+    thisRef.current.props = props;
     return createPortal(props.children, marker.getElement());
   })
 );

--- a/modules/react-maplibre/src/components/marker.ts
+++ b/modules/react-maplibre/src/components/marker.ts
@@ -126,11 +126,8 @@ export const Marker = memo(
     }
     const classNameDiff = compareClassNames(oldProps.className, props.className);
     if (classNameDiff) {
-      for (const c of classNameDiff[0]) {
-        marker.addClassName(c);
-      }
-      for (const c of classNameDiff[1]) {
-        marker.removeClassName(c);
+      for (const c of classNameDiff) {
+        marker.toggleClassName(c);
       }
     }
 

--- a/modules/react-maplibre/src/components/popup.ts
+++ b/modules/react-maplibre/src/components/popup.ts
@@ -78,15 +78,13 @@ export const Popup = memo(
         popup.setOffset(props.offset);
       }
       if (oldProps.anchor !== props.anchor || oldProps.maxWidth !== props.maxWidth) {
+        popup.options.anchor = props.anchor;
         popup.setMaxWidth(props.maxWidth);
       }
       const classNameDiff = compareClassNames(oldProps.className, props.className);
       if (classNameDiff) {
-        for (const c of classNameDiff[0]) {
-          popup.addClassName(c);
-        }
-        for (const c of classNameDiff[1]) {
-          popup.removeClassName(c);
+        for (const c of classNameDiff) {
+          popup.toggleClassName(c);
         }
       }
       thisRef.current.props = props;

--- a/modules/react-maplibre/src/components/popup.ts
+++ b/modules/react-maplibre/src/components/popup.ts
@@ -9,6 +9,7 @@ import type {PopupEvent} from '../types/events';
 
 import {MapContext} from './map';
 import {deepEqual} from '../utils/deep-equal';
+import {compareClassNames} from '../utils/compare-class-names';
 
 export type PopupProps = PopupOptions & {
   /** Longitude of the anchor location */
@@ -24,11 +25,6 @@ export type PopupProps = PopupOptions & {
   children?: React.ReactNode;
 };
 
-// Adapted from https://github.com/mapbox/mapbox-gl-js/blob/v1.13.0/src/ui/popup.js
-function getClassList(className: string) {
-  return new Set(className ? className.trim().split(/\s+/) : []);
-}
-
 /* eslint-disable complexity,max-statements */
 export const Popup = memo(
   forwardRef((props: PopupProps, ref: React.Ref<PopupInstance>) => {
@@ -37,7 +33,6 @@ export const Popup = memo(
       return document.createElement('div');
     }, []);
     const thisRef = useRef({props});
-    thisRef.current.props = props;
 
     const popup: PopupInstance = useMemo(() => {
       const options = {...props};
@@ -75,32 +70,26 @@ export const Popup = memo(
     useImperativeHandle(ref, () => popup, []);
 
     if (popup.isOpen()) {
+      const oldProps = thisRef.current.props;
       if (popup.getLngLat().lng !== props.longitude || popup.getLngLat().lat !== props.latitude) {
         popup.setLngLat([props.longitude, props.latitude]);
       }
-      if (props.offset && !deepEqual(popup.options.offset, props.offset)) {
+      if (props.offset && !deepEqual(oldProps.offset, props.offset)) {
         popup.setOffset(props.offset);
       }
-      if (popup.options.anchor !== props.anchor || popup.options.maxWidth !== props.maxWidth) {
-        popup.options.anchor = props.anchor;
+      if (oldProps.anchor !== props.anchor || oldProps.maxWidth !== props.maxWidth) {
         popup.setMaxWidth(props.maxWidth);
       }
-      if (popup.options.className !== props.className) {
-        const prevClassList = getClassList(popup.options.className);
-        const nextClassList = getClassList(props.className);
-
-        for (const c of prevClassList) {
-          if (!nextClassList.has(c)) {
-            popup.removeClassName(c);
-          }
+      const classNameDiff = compareClassNames(oldProps.className, props.className);
+      if (classNameDiff) {
+        for (const c of classNameDiff[0]) {
+          popup.addClassName(c);
         }
-        for (const c of nextClassList) {
-          if (!prevClassList.has(c)) {
-            popup.addClassName(c);
-          }
+        for (const c of classNameDiff[1]) {
+          popup.removeClassName(c);
         }
-        popup.options.className = props.className;
       }
+      thisRef.current.props = props;
     }
 
     return createPortal(props.children, container);

--- a/modules/react-maplibre/src/utils/compare-class-names.ts
+++ b/modules/react-maplibre/src/utils/compare-class-names.ts
@@ -1,0 +1,36 @@
+/** Compare two classNames string and return the difference */
+export function compareClassNames(
+  prevClassName: string | undefined,
+  nextClassName: string | undefined
+): [added: string[], removed: string[]] | null {
+  if (prevClassName === nextClassName) {
+    return null;
+  }
+
+  const prevClassList = getClassList(prevClassName);
+  const nextClassList = getClassList(nextClassName);
+  const added: string[] = [];
+  const removed: string[] = [];
+
+  for (const c of prevClassList) {
+    if (!nextClassList.has(c)) {
+      removed.push(c);
+    }
+  }
+
+  if (removed.length === 0 && prevClassList.size === nextClassList.size) {
+    return null;
+  }
+
+  for (const c of nextClassList) {
+    if (!prevClassList.has(c)) {
+      added.push(c);
+    }
+  }
+
+  return [added, removed];
+}
+
+function getClassList(className: string | undefined) {
+  return new Set(className ? className.trim().split(/\s+/) : []);
+}

--- a/modules/react-maplibre/src/utils/compare-class-names.ts
+++ b/modules/react-maplibre/src/utils/compare-class-names.ts
@@ -2,33 +2,26 @@
 export function compareClassNames(
   prevClassName: string | undefined,
   nextClassName: string | undefined
-): [added: string[], removed: string[]] | null {
+): string[] | null {
   if (prevClassName === nextClassName) {
     return null;
   }
 
   const prevClassList = getClassList(prevClassName);
   const nextClassList = getClassList(nextClassName);
-  const added: string[] = [];
-  const removed: string[] = [];
-
-  for (const c of prevClassList) {
-    if (!nextClassList.has(c)) {
-      removed.push(c);
-    }
-  }
-
-  if (removed.length === 0 && prevClassList.size === nextClassList.size) {
-    return null;
-  }
+  const diff: string[] = [];
 
   for (const c of nextClassList) {
     if (!prevClassList.has(c)) {
-      added.push(c);
+      diff.push(c);
     }
   }
-
-  return [added, removed];
+  for (const c of prevClassList) {
+    if (!nextClassList.has(c)) {
+      diff.push(c);
+    }
+  }
+  return diff.length === 0 ? null : diff;
 }
 
 function getClassList(className: string | undefined) {

--- a/modules/react-maplibre/test/components/marker.spec.jsx
+++ b/modules/react-maplibre/test/components/marker.spec.jsx
@@ -48,6 +48,7 @@ test('Marker', async t => {
         offset={[0, 1]}
         rotation={30}
         draggable
+        className="classA"
         pitchAlignment="viewport"
         rotationAlignment="viewport"
         onDragStart={() => (callbackType = 'dragstart')}
@@ -63,6 +64,7 @@ test('Marker', async t => {
   t.not(rotation, marker.getRotation(), 'rotation is updated');
   t.not(pitchAlignment, marker.getPitchAlignment(), 'pitchAlignment is updated');
   t.not(rotationAlignment, marker.getRotationAlignment(), 'rotationAlignment is updated');
+  t.ok(marker._element.classList.contains('classA'), 'className is updated');
 
   marker.fire('dragstart');
   t.is(callbackType, 'dragstart', 'onDragStart called');

--- a/modules/react-maplibre/test/components/popup.spec.jsx
+++ b/modules/react-maplibre/test/components/popup.spec.jsx
@@ -67,8 +67,7 @@ test('Popup', async t => {
     </Map>
   );
   await sleep(1);
-
-  t.is(popup.options.className, 'classA', 'className is updated');
+  t.ok(popup._container.classList.contains('classA'), 'className is updated');
 
   root.unmount();
   t.end();

--- a/modules/react-maplibre/test/utils/compare-class-names.spec.js
+++ b/modules/react-maplibre/test/utils/compare-class-names.spec.js
@@ -1,0 +1,52 @@
+import test from 'tape-promise/tape';
+import {compareClassNames} from '@vis.gl/react-maplibre/utils/compare-class-names';
+
+test('compareClassNames', t => {
+  const TEST_CASES = [
+    {
+      title: 'Empty class names',
+      prevClassName: '',
+      nextClassName: '',
+      output: null
+    },
+    {
+      title: 'Identical class names',
+      prevClassName: 'marker active',
+      nextClassName: 'active  marker ',
+      output: null
+    },
+    {
+      title: 'Addition',
+      prevClassName: undefined,
+      nextClassName: 'marker',
+      output: [['marker'], []]
+    },
+    {
+      title: 'Addition',
+      prevClassName: 'marker',
+      nextClassName: 'marker active',
+      output: [['active'], []]
+    },
+    {
+      title: 'Removal',
+      prevClassName: 'marker active',
+      nextClassName: 'marker',
+      output: [[], ['active']]
+    },
+    {
+      title: 'Multiple addition & removal',
+      prevClassName: 'marker active',
+      nextClassName: 'marker hovered hidden',
+      output: [['hovered', 'hidden'], ['active']]
+    }
+  ];
+
+  for (const testCase of TEST_CASES) {
+    t.deepEqual(
+      compareClassNames(testCase.prevClassName, testCase.nextClassName),
+      testCase.output,
+      testCase.title
+    );
+  }
+  t.end();
+});

--- a/modules/react-maplibre/test/utils/compare-class-names.spec.js
+++ b/modules/react-maplibre/test/utils/compare-class-names.spec.js
@@ -19,25 +19,25 @@ test('compareClassNames', t => {
       title: 'Addition',
       prevClassName: undefined,
       nextClassName: 'marker',
-      output: [['marker'], []]
+      output: ['marker']
     },
     {
       title: 'Addition',
       prevClassName: 'marker',
       nextClassName: 'marker active',
-      output: [['active'], []]
+      output: ['active']
     },
     {
       title: 'Removal',
       prevClassName: 'marker active',
       nextClassName: 'marker',
-      output: [[], ['active']]
+      output: ['active']
     },
     {
       title: 'Multiple addition & removal',
       prevClassName: 'marker active',
       nextClassName: 'marker hovered hidden',
-      output: [['hovered', 'hidden'], ['active']]
+      output: ['hovered', 'hidden', 'active']
     }
   ];
 

--- a/modules/react-maplibre/test/utils/index.js
+++ b/modules/react-maplibre/test/utils/index.js
@@ -2,3 +2,4 @@ import './deep-equal.spec';
 import './transform.spec';
 import './style-utils.spec';
 import './apply-react-style.spec';
+import './compare-class-names.spec';


### PR DESCRIPTION
Closes #2465

- Consistently handle `props.className` change in react-mapbox and react-maplibre
- Test for Marker component `className` prop change
- Not changing mapbox-legacy because `marker.toggleClassName` does not exist in v1