### PR TITLE
Fix type resolution for subpath exports when using `moduleResolution: node`

### DIFF
--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -32,6 +32,19 @@
       "import": "./dist/mapbox-legacy/index.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "mapbox": [
+        "./dist/mapbox.d.ts"
+      ],
+      "maplibre": [
+        "./dist/maplibre.d.ts"
+      ],
+      "mapbox-legacy": [
+        "./dist/mapbox-legacy/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
TypeScript isn't able to resolve the types for subpath exports (e.g. `react-map-gl/mapbox`) when using `moduleResolution: node` in consuming apps (see this [StackOverflow issue](https://stackoverflow.com/questions/58990498/package-json-exports-field-not-working-with-typescript)).

Adding `typesVersions` with `*` to target all TypeScript versions works around this limitation.