### PR TITLE
Fix style loading check on Source layers (#2377)

### DIFF
--- a/modules/react-mapbox/src/components/source.ts
+++ b/modules/react-mapbox/src/components/source.ts
@@ -26,7 +26,7 @@ let sourceCounter = 0;
 
 function createSource(map: MapInstance, id: string, props: SourceProps) {
   // @ts-ignore
-  if (map.style && map.style._loaded) {
+  if (map.isStyleLoaded()) {
     const options = {...props};
     delete options.id;
     delete options.children;


### PR DESCRIPTION
Closes #2377 

Fixed the `Style is not done loading` error by using a map.isStyleLoaded() function check in place of the primitive values. 