### PR TITLE
fix update-release-branch.sh, links for v8 website

### DIFF
--- a/docs/api-reference/mapbox/attribution-control.md
+++ b/docs/api-reference/mapbox/attribution-control.md
@@ -52,4 +52,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[attribution-control.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/attribution-control.ts)
+[attribution-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/attribution-control.ts)

--- a/docs/api-reference/mapbox/fullscreen-control.md
+++ b/docs/api-reference/mapbox/fullscreen-control.md
@@ -49,4 +49,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[fullscreen-control.ts](https://github.com/visgl/react-map-gl/tree/7.1-release/src/components/fullscreen-control.tsx)
+[fullscreen-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/fullscreen-control.ts)

--- a/docs/api-reference/mapbox/geolocate-control.md
+++ b/docs/api-reference/mapbox/geolocate-control.md
@@ -102,4 +102,4 @@ function App() {
 
 ## Source
 
-[geolocate-control.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/geolocate-control.ts)
+[geolocate-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/geolocate-control.ts)

--- a/docs/api-reference/mapbox/layer.md
+++ b/docs/api-reference/mapbox/layer.md
@@ -68,4 +68,4 @@ Note that layers are added by the order that they mount. They are *NOT* reordere
 
 ## Source
 
-[layer.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/layer.ts)
+[layer.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/layer.ts)

--- a/docs/api-reference/mapbox/map-provider.md
+++ b/docs/api-reference/mapbox/map-provider.md
@@ -23,4 +23,4 @@ See [useMap](./use-map.md) for more information.
 
 ## Source
 
-[use-map.tsx](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/use-map.tsx)
+[use-map.tsx](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/use-map.tsx)

--- a/docs/api-reference/mapbox/map.md
+++ b/docs/api-reference/mapbox/map.md
@@ -568,4 +568,4 @@ Returns the native `Map` ([Mapbox](https://docs.mapbox.com/mapbox-gl-js/api/map/
 
 ## Source
 
-[map.tsx](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/map.tsx)
+[map.tsx](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/map.tsx)

--- a/docs/api-reference/mapbox/marker.md
+++ b/docs/api-reference/mapbox/marker.md
@@ -148,4 +148,4 @@ function App() {
 
 ## Source
 
-[marker.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/marker.ts)
+[marker.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/marker.ts)

--- a/docs/api-reference/mapbox/navigation-control.md
+++ b/docs/api-reference/mapbox/navigation-control.md
@@ -52,4 +52,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[navigation-control.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/navigation-control.ts)
+[navigation-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/navigation-control.ts)

--- a/docs/api-reference/mapbox/popup.md
+++ b/docs/api-reference/mapbox/popup.md
@@ -118,4 +118,4 @@ function App() {
 
 ## Source
 
-[popup.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/popup.ts)
+[popup.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/popup.ts)

--- a/docs/api-reference/mapbox/scale-control.md
+++ b/docs/api-reference/mapbox/scale-control.md
@@ -57,4 +57,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[scale-control.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/scale-control.ts)
+[scale-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/scale-control.ts)

--- a/docs/api-reference/mapbox/source.md
+++ b/docs/api-reference/mapbox/source.md
@@ -62,4 +62,4 @@ Required. Type of the source.
 
 ## Source
 
-[source.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/source.ts)
+[source.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/source.ts)

--- a/docs/api-reference/mapbox/use-control.md
+++ b/docs/api-reference/mapbox/use-control.md
@@ -85,4 +85,4 @@ Returns:
 
 ## Source
 
-[use-control.ts](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/use-control.ts)
+[use-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/use-control.ts)

--- a/docs/api-reference/mapbox/use-map.md
+++ b/docs/api-reference/mapbox/use-map.md
@@ -57,7 +57,7 @@ function NavigateButton() {
 ```
 
 
-See a full example [here](https://github.com/visgl/react-map-gl/tree/7.0-release/examples/get-started/hook).
+See a full example [here](https://github.com/visgl/react-map-gl/tree/8.0-release/examples/get-started/hook).
 
 ## Signature
 
@@ -69,4 +69,4 @@ If the hook is used inside a decendent of a `Map` component, the returned object
 
 ## Source
 
-[use-map.tsx](https://github.com/visgl/react-map-gl/tree/7.0-release/src/components/use-map.tsx)
+[use-map.tsx](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-mapbox/src/components/use-map.tsx)

--- a/docs/api-reference/maplibre/attribution-control.md
+++ b/docs/api-reference/maplibre/attribution-control.md
@@ -53,4 +53,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[attribution-control.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/attribution-control.ts)
+[attribution-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/attribution-control.ts)

--- a/docs/api-reference/maplibre/fullscreen-control.md
+++ b/docs/api-reference/maplibre/fullscreen-control.md
@@ -48,4 +48,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[fullscreen-control.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/fullscreen-control.ts)
+[fullscreen-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/fullscreen-control.ts)

--- a/docs/api-reference/maplibre/geolocate-control.md
+++ b/docs/api-reference/maplibre/geolocate-control.md
@@ -103,4 +103,4 @@ function App() {
 
 ## Source
 
-[geolocate-control.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/geolocate-control.ts)
+[geolocate-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/geolocate-control.ts)

--- a/docs/api-reference/maplibre/layer.md
+++ b/docs/api-reference/maplibre/layer.md
@@ -68,4 +68,4 @@ Note that layers are added by the order that they mount. They are *NOT* reordere
 
 ## Source
 
-[layer.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/layer.ts)
+[layer.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/layer.ts)

--- a/docs/api-reference/maplibre/logo-control.md
+++ b/docs/api-reference/maplibre/logo-control.md
@@ -50,4 +50,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[logo-control.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/logo-control.ts)
+[logo-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/logo-control.ts)

--- a/docs/api-reference/maplibre/map-provider.md
+++ b/docs/api-reference/maplibre/map-provider.md
@@ -23,4 +23,4 @@ See [useMap](./use-map.md) for more information.
 
 ## Source
 
-[use-map.tsx](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/use-map.tsx)
+[use-map.tsx](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/use-map.tsx)

--- a/docs/api-reference/maplibre/map.md
+++ b/docs/api-reference/maplibre/map.md
@@ -549,4 +549,4 @@ Returns the native [Map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Ma
 
 ## Source
 
-[map.tsx](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/map.tsx)
+[map.tsx](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/map.tsx)

--- a/docs/api-reference/maplibre/marker.md
+++ b/docs/api-reference/maplibre/marker.md
@@ -146,4 +146,4 @@ function App() {
 
 ## Source
 
-[marker.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/marker.ts)
+[marker.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/marker.ts)

--- a/docs/api-reference/maplibre/navigation-control.md
+++ b/docs/api-reference/maplibre/navigation-control.md
@@ -52,4 +52,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[navigation-control.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/navigation-control.ts)
+[navigation-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/navigation-control.ts)

--- a/docs/api-reference/maplibre/popup.md
+++ b/docs/api-reference/maplibre/popup.md
@@ -119,4 +119,4 @@ function App() {
 
 ## Source
 
-[popup.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/popup.ts)
+[popup.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/popup.ts)

--- a/docs/api-reference/maplibre/scale-control.md
+++ b/docs/api-reference/maplibre/scale-control.md
@@ -56,4 +56,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[scale-control.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/scale-control.ts)
+[scale-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/scale-control.ts)

--- a/docs/api-reference/maplibre/source.md
+++ b/docs/api-reference/maplibre/source.md
@@ -61,4 +61,4 @@ Required. Type of the source.
 
 ## Source
 
-[source.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/source.ts)
+[source.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/source.ts)

--- a/docs/api-reference/maplibre/terrain-control.md
+++ b/docs/api-reference/maplibre/terrain-control.md
@@ -82,4 +82,4 @@ Placement of the control relative to the map.
 
 ## Source
 
-[terrain-control.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/terrain-control.ts)
+[terrain-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/terrain-control.ts)

--- a/docs/api-reference/maplibre/use-control.md
+++ b/docs/api-reference/maplibre/use-control.md
@@ -84,4 +84,4 @@ Returns:
 
 ## Source
 
-[use-control.ts](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/use-control.ts)
+[use-control.ts](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/use-control.ts)

--- a/docs/api-reference/maplibre/use-map.md
+++ b/docs/api-reference/maplibre/use-map.md
@@ -55,7 +55,7 @@ function NavigateButton() {
 ```
 
 
-See a full example [here](https://github.com/visgl/react-map-gl/tree/master/examples/get-started/hook).
+See a full example [here](https://github.com/visgl/react-map-gl/tree/8.0-release/examples/get-started/hook).
 
 ## Signature
 
@@ -67,4 +67,4 @@ If the hook is used inside a decendent of a `Map` component, the returned object
 
 ## Source
 
-[use-map.tsx](https://github.com/visgl/react-map-gl/tree/master/modules/maplibre/src/components/use-map.tsx)
+[use-map.tsx](https://github.com/visgl/react-map-gl/tree/8.0-release/modules/react-maplibre/src/components/use-map.tsx)

--- a/docs/get-started/adding-custom-data.md
+++ b/docs/get-started/adding-custom-data.md
@@ -51,12 +51,12 @@ function App() {
 
 For details about data sources and layer configuration, check out the [Mapbox style specification](https://www.mapbox.com/mapbox-gl-js/style-spec).
 
-For dynamically updating data sources and layers, check out the [GeoJSON](http://visgl.github.io/react-map-gl/examples/geojson) and [GeoJSON animation](http://visgl.github.io/react-map-gl/examples/geojson-animation) examples.
+For dynamically updating data sources and layers, check out the [GeoJSON](https://visgl.github.io/react-map-gl/examples/maplibre/geojson) and [GeoJSON animation](http://visgl.github.io/react-map-gl/examples/maplibre/geojson-animation) examples.
 
 
 ## Custom Overlays
 
-You can implement a custom HTML or SVG overlay on top of the map that redraws whenever the camera changes. By calling `map.project()` you can adjust the DOM or CSS properties so that the customly-drawn features are always aligned with the map. See a full example [here](https://github.com/visgl/react-map-gl/tree/7.0-release/examples/custom-overlay).
+You can implement a custom HTML or SVG overlay on top of the map that redraws whenever the camera changes. By calling `map.project()` you can adjust the DOM or CSS properties so that the customly-drawn features are always aligned with the map. See a full example [here](https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/custom-overlay).
 
 
 ## Other vis.gl Libraries

--- a/docs/get-started/state-management.md
+++ b/docs/get-started/state-management.md
@@ -8,7 +8,7 @@ There are two ways to use a [Map](../api-reference/maplibre/map.md):
 
 ## Uncontrolled Map
 
-You may clone a full app configuration for this example [here](https://github.com/visgl/react-map-gl/tree/7.0-release/examples/get-started/basic).
+You may clone a full app configuration for this example [here](https://github.com/visgl/react-map-gl/tree/8.0-release/examples/get-started/basic).
 
 ```tsx
 import * as React from 'react';
@@ -28,7 +28,7 @@ function App() {
 
 ## Controlled Map
 
-You may clone a full app configuration for this example [here](https://github.com/visgl/react-map-gl/tree/7.0-release/examples/get-started/controlled).
+You may clone a full app configuration for this example [here](https://github.com/visgl/react-map-gl/tree/8.0-release/examples/get-started/controlled).
 
 ```tsx
 import * as React from 'react';
@@ -51,8 +51,8 @@ function App() {
 
 A real-world application likely uses more complicated state flows:
 
-- Using map with a state store (Redux) [example](https://github.com/visgl/react-map-gl/tree/7.0-release/examples/get-started/redux)
-- Using map with SSR (Next.js) [example](https://github.com/visgl/react-map-gl/tree/7.0-release/examples/get-started/nextjs)
+- Using map with a state store (Redux) [example](https://github.com/visgl/react-map-gl/tree/8.0-release/examples/get-started/redux)
+- Using map with SSR (Next.js) [example](https://github.com/visgl/react-map-gl/tree/8.0-release/examples/get-started/nextjs)
 
 
 ## Custom Camera Constraints

--- a/examples/mapbox/clusters/src/control-panel.tsx
+++ b/examples/mapbox/clusters/src/control-panel.tsx
@@ -7,7 +7,7 @@ function ControlPanel() {
       <p>Use Mapbox GL JS' built-in functions to visualize points as clusters.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/clusters"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/clusters"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/controls/src/control-panel.tsx
+++ b/examples/mapbox/controls/src/control-panel.tsx
@@ -16,7 +16,7 @@ function ControlPanel() {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/controls"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/controls"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/custom-cursor/src/control-panel.tsx
+++ b/examples/mapbox/custom-cursor/src/control-panel.tsx
@@ -50,7 +50,7 @@ function StyleControls(props) {
       <p>Customize the cursor based on interactivity.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/custom-cursor"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/custom-cursor"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/custom-overlay/src/control-panel.tsx
+++ b/examples/mapbox/custom-overlay/src/control-panel.tsx
@@ -32,7 +32,7 @@ function ControlPanel() {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/custom-overlay"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/custom-overlay"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/draggable-markers/src/control-panel.tsx
+++ b/examples/mapbox/draggable-markers/src/control-panel.tsx
@@ -26,7 +26,7 @@ function ControlPanel(props: {events: Record<string, LngLat>}) {
       </div>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/draggable-markers"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/draggable-markers"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/draw-polygon/src/control-panel.tsx
+++ b/examples/mapbox/draw-polygon/src/control-panel.tsx
@@ -18,7 +18,7 @@ function ControlPanel(props) {
       )}
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/draw-polygon"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/draw-polygon"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/filter/src/control-panel.tsx
+++ b/examples/mapbox/filter/src/control-panel.tsx
@@ -7,7 +7,7 @@ function ControlPanel() {
       <p>Hover over counties to highlight counties that share the same name.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/filter"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/filter"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/geocoder/src/control-panel.tsx
+++ b/examples/mapbox/geocoder/src/control-panel.tsx
@@ -6,7 +6,7 @@ function ControlPanel() {
       <h3>Geocoder</h3>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/geocoder"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/geocoder"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/geojson-animation/src/control-panel.tsx
+++ b/examples/mapbox/geojson-animation/src/control-panel.tsx
@@ -7,7 +7,7 @@ function ControlPanel() {
       <p>Render animation by updating GeoJSON data source.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/geojson-animation"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/geojson-animation"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/geojson/src/control-panel.tsx
+++ b/examples/mapbox/geojson/src/control-panel.tsx
@@ -18,7 +18,7 @@ function ControlPanel(props) {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/geojson"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/geojson"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/heatmap/src/control-panel.tsx
+++ b/examples/mapbox/heatmap/src/control-panel.tsx
@@ -57,7 +57,7 @@ function ControlPanel(props) {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/heatmap"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/heatmap"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/interaction/src/control-panel.tsx
+++ b/examples/mapbox/interaction/src/control-panel.tsx
@@ -47,7 +47,7 @@ function ControlPanel(props) {
       <p>Turn interactive features off/on.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/interaction"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/interaction"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/layers/src/control-panel.tsx
+++ b/examples/mapbox/layers/src/control-panel.tsx
@@ -82,7 +82,7 @@ function StyleControls(props) {
       <p>Dynamically show/hide map layers and change color with Immutable map style.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/layers"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/layers"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/side-by-side/src/control-panel.tsx
+++ b/examples/mapbox/side-by-side/src/control-panel.tsx
@@ -26,7 +26,7 @@ function ControlPanel(props: {mode: Mode; onModeChange: (newMode: Mode) => void}
 
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/side-by-side"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/side-by-side"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/terrain/src/control-panel.tsx
+++ b/examples/mapbox/terrain/src/control-panel.tsx
@@ -8,7 +8,7 @@ function ControlPanel() {
 
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/terrain"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/terrain"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/viewport-animation/src/control-panel.tsx
+++ b/examples/mapbox/viewport-animation/src/control-panel.tsx
@@ -9,7 +9,7 @@ function ControlPanel(props) {
       <p>Smooth animate of the viewport.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/viewport-animation"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/viewport-animation"
           target="_new"
         >
           View Code ↗

--- a/examples/mapbox/zoom-to-bounds/src/control-panel.tsx
+++ b/examples/mapbox/zoom-to-bounds/src/control-panel.tsx
@@ -7,7 +7,7 @@ function ControlPanel() {
       <p>Click on a San Fransisco Neighborhood to zoom in.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-map-gl/tree/7.0-release/examples/zoom-to-bounds"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/mapbox/zoom-to-bounds"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/clusters/src/control-panel.tsx
+++ b/examples/maplibre/clusters/src/control-panel.tsx
@@ -7,7 +7,7 @@ function ControlPanel() {
       <p>Use Maplibre GL JS' built-in functions to visualize points as clusters.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/clusters"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/clusters"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/controls/src/control-panel.tsx
+++ b/examples/maplibre/controls/src/control-panel.tsx
@@ -16,7 +16,7 @@ function ControlPanel() {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/controls"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/controls"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/custom-cursor/src/control-panel.tsx
+++ b/examples/maplibre/custom-cursor/src/control-panel.tsx
@@ -50,7 +50,7 @@ function StyleControls(props) {
       <p>Customize the cursor based on interactivity.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/custom-cursor"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/custom-cursor"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/custom-overlay/src/control-panel.tsx
+++ b/examples/maplibre/custom-overlay/src/control-panel.tsx
@@ -32,7 +32,7 @@ function ControlPanel() {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/custom-overlay"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/custom-overlay"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/draggable-markers/src/control-panel.tsx
+++ b/examples/maplibre/draggable-markers/src/control-panel.tsx
@@ -26,7 +26,7 @@ function ControlPanel(props: {events: Record<string, LngLat>}) {
       </div>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/draggable-markers"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/draggable-markers"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/draw-polygon/src/control-panel.tsx
+++ b/examples/maplibre/draw-polygon/src/control-panel.tsx
@@ -18,7 +18,7 @@ function ControlPanel(props) {
       )}
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/draw-polygon"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/draw-polygon"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/filter/src/control-panel.tsx
+++ b/examples/maplibre/filter/src/control-panel.tsx
@@ -7,7 +7,7 @@ function ControlPanel() {
       <p>Hover over counties to highlight counties that share the same name.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/filter"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/filter"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/geocoder/src/control-panel.tsx
+++ b/examples/maplibre/geocoder/src/control-panel.tsx
@@ -6,7 +6,7 @@ function ControlPanel() {
       <h3>Geocoder</h3>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/geocoder"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/geocoder"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/geojson-animation/src/control-panel.tsx
+++ b/examples/maplibre/geojson-animation/src/control-panel.tsx
@@ -7,7 +7,7 @@ function ControlPanel() {
       <p>Render animation by updating GeoJSON data source.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/geojson-animation"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/geojson-animation"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/geojson/src/control-panel.tsx
+++ b/examples/maplibre/geojson/src/control-panel.tsx
@@ -15,7 +15,7 @@ function ControlPanel(props) {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/geojson"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/geojson"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/globe/src/control-panel.tsx
+++ b/examples/maplibre/globe/src/control-panel.tsx
@@ -8,7 +8,7 @@ function ControlPanel() {
 
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/globe"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/globe"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/heatmap/src/control-panel.tsx
+++ b/examples/maplibre/heatmap/src/control-panel.tsx
@@ -57,7 +57,7 @@ function ControlPanel(props) {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/heatmap"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/heatmap"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/interaction/src/control-panel.tsx
+++ b/examples/maplibre/interaction/src/control-panel.tsx
@@ -47,7 +47,7 @@ function ControlPanel(props) {
       <p>Turn interactive features off/on.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/interaction"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/interaction"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/layers/src/control-panel.tsx
+++ b/examples/maplibre/layers/src/control-panel.tsx
@@ -82,7 +82,7 @@ function StyleControls(props) {
       <p>Dynamically show/hide map layers and change color with Immutable map style.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/layers"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/layers"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/side-by-side/src/control-panel.tsx
+++ b/examples/maplibre/side-by-side/src/control-panel.tsx
@@ -26,7 +26,7 @@ function ControlPanel(props: {mode: Mode; onModeChange: (newMode: Mode) => void}
 
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/side-by-side"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/side-by-side"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/terrain/src/control-panel.tsx
+++ b/examples/maplibre/terrain/src/control-panel.tsx
@@ -8,7 +8,7 @@ function ControlPanel() {
 
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/terrain"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/terrain"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/viewport-animation/src/control-panel.tsx
+++ b/examples/maplibre/viewport-animation/src/control-panel.tsx
@@ -9,7 +9,7 @@ function ControlPanel(props) {
       <p>Smooth animate of the viewport.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/viewport-animation"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/viewport-animation"
           target="_new"
         >
           View Code ↗

--- a/examples/maplibre/zoom-to-bounds/src/control-panel.tsx
+++ b/examples/maplibre/zoom-to-bounds/src/control-panel.tsx
@@ -7,7 +7,7 @@ function ControlPanel() {
       <p>Click on a San Fransisco Neighborhood to zoom in.</p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-maplibre/tree/1.0-release/examples/zoom-to-bounds"
+          href="https://github.com/visgl/react-map-gl/tree/8.0-release/examples/maplibre/zoom-to-bounds"
           target="_new"
         >
           View Code ↗

--- a/scripts/update-release-branch.sh
+++ b/scripts/update-release-branch.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 # Example:
-# update-release-branch.sh 6.3
+# update-release-branch.sh 8.0
 
 set -e
 
@@ -10,14 +10,13 @@ VERSION=`echo "$1.0"`
 echo "Updating branch to ${BRANCH}..."
 
 # Replace source links in docs and examples
-find docs -iname "*.md" -type f -exec sed -i '' -E "s/react-map-gl\/(tree|blob)\/(master|[0-9\.]+-release)/react-map-gl\/tree\/${BRANCH}/g" {} \;
-find examples -maxdepth 0 -iname "*.md" -type f -exec sed -i '' -E "s/react-map-gl\/(tree|blob)\/(master|[0-9\.]+-release)/react-map-gl\/tree\/${BRANCH}/g" {} \;
-find examples/*/src -iname "*.js" -type f -exec sed -i '' -E "s/react-map-gl\/(tree|blob)\/(master|[0-9\.]+-release)/react-map-gl\/tree\/${BRANCH}/g" {} \;
+find docs -mindepth 2 -iname "*.md" -exec perl -i -pe "s/react-map-gl\/(tree|blob)\/(master|[0-9\.]+-release)/react-map-gl\/tree\/${BRANCH}/g" {} \;
+find examples \( -iname "*.js" -iname "*.jsx" -iname "*.ts" -o -iname "*.tsx" \) -type f -exec perl -i -pe "s/react-map-gl\/(tree|blob)\/(master|[0-9\.]+-release)/react-map-gl\/tree\/${BRANCH}/g" {} \;
 
 # Bump dependencies in examples
 update_dep() {
-  FILE=$1
-  VERSION=$2
+  local FILE=$1
+  local VERSION=$2
   cat $FILE | jq ".dependencies |= . + \
   with_entries(select(.key | match(\"react-map-gl\")) | .value |= \"^${VERSION}\")" > temp
   mv temp $FILE
@@ -25,4 +24,4 @@ update_dep() {
 
 # https://stackoverflow.com/questions/4321456/find-exec-a-shell-function-in-linux
 export -f update_dep
-find examples/*/package.json -exec bash -c 'update_dep "$0" $1' {} $VERSION \;
+find examples -type f -name "package.json" -exec bash -c 'update_dep "$0" $1' {} $VERSION \;


### PR DESCRIPTION
The `update-release-branch.sh` script was not updating `.ts` and `.tsx` files and was relying on an old repo structure. Let's make the script work with the new structure and then update links in the docs and examples, replacing outdated versions (e.g., `7.0-release`, `react-mapbox-gl`) with the correct v8 links.

This fixes #2497.