### PR TITLE
marker.ts: `undefined` instead of `null`

### DIFF
--- a/modules/react-maplibre/src/components/marker.ts
+++ b/modules/react-maplibre/src/components/marker.ts
@@ -43,7 +43,7 @@ export const Marker = memo(
       });
       const options = {
         ...props,
-        element: hasChildren ? document.createElement('div') : null
+        element: hasChildren ? document.createElement('div') : undefined
       };
 
       const mk = new mapLib.Marker(options);


### PR DESCRIPTION
With `null` I am getting
> <img width="894" alt="image" src="https://github.com/user-attachments/assets/9a6783de-5df9-4ea6-958e-7bc74fe0bdbd" />

With `undefined` TS is happy
> <img width="514" alt="image" src="https://github.com/user-attachments/assets/9e4ca73e-9d54-484c-86cf-27a30f899b97" />

I am using
```
    "maplibre-gl": "^5.2.0",
    "react-map-gl": "^8.0.1",
```

Did not do a real test, though, just reloaded my component.