### PR TITLE
feat(mapbox): Replace shadow transform with proxied approach

### DIFF
--- a/docs/api-reference/mapbox/types.md
+++ b/docs/api-reference/mapbox/types.md
@@ -168,6 +168,7 @@ An object with the following fields:
 - `zoom`: number - The zoom level.
 - `pitch`: number - The pitch (tilt) of the map, in degrees.
 - `bearing`: number - The bearing (rotation) of the map, in degrees.
+- `elevation`: number|undefined - The map center elevation from sea leavel on terrain surface, if any
 
 
 ## Events

--- a/examples/vite.config.local.js
+++ b/examples/vite.config.local.js
@@ -9,8 +9,8 @@ export default defineConfig(async () => {
     resolve: {
       alias: {
         // Use root dependencies
-        'react-map-gl/mapbox': join(rootDir, './modules/main/src/mapbox.ts'),
-        'react-map-gl/maplibre': join(rootDir, './modules/main/src/maplibre.ts'),
+        'react-map-gl/mapbox': join(rootDir, './modules/react-mapbox/src'),
+        'react-map-gl/maplibre': join(rootDir, './modules/react-maplibre/src'),
         react: join(rootDir, './node_modules/react'),
         'react-dom': join(rootDir, './node_modules/react-dom')
       }

--- a/modules/react-mapbox/src/components/source.ts
+++ b/modules/react-mapbox/src/components/source.ts
@@ -25,7 +25,6 @@ export type SourceProps = (SourceSpecification | CanvasSourceSpecification) & {
 let sourceCounter = 0;
 
 function createSource(map: MapInstance, id: string, props: SourceProps) {
-  // @ts-ignore
   if (map.isStyleLoaded()) {
     const options = {...props};
     delete options.id;
@@ -89,10 +88,12 @@ export function Source(props: SourceProps) {
     if (map) {
       /* global setTimeout */
       const forceUpdate = () => setTimeout(() => setStyleLoaded(version => version + 1), 0);
+      map.on('load', forceUpdate);
       map.on('styledata', forceUpdate);
       forceUpdate();
 
       return () => {
+        map.off('load', forceUpdate);
         map.off('styledata', forceUpdate);
         // @ts-ignore
         if (map.style && map.style._loaded && map.getSource(id)) {

--- a/modules/react-mapbox/src/mapbox/proxy-transform.ts
+++ b/modules/react-mapbox/src/mapbox/proxy-transform.ts
@@ -1,5 +1,5 @@
-import type {Transform, LngLat} from '../types/internal';
-import type {ViewState} from '../types/common';
+import type {Transform} from '../types/internal';
+import type {ViewState, LngLat} from '../types/common';
 import {applyViewStateToTransform, isViewStateControlled} from '../utils/transform';
 
 /**

--- a/modules/react-mapbox/src/mapbox/proxy-transform.ts
+++ b/modules/react-mapbox/src/mapbox/proxy-transform.ts
@@ -1,0 +1,142 @@
+import type {Transform} from '../types/internal';
+import type {ViewState, LngLat} from '../types/common';
+import { applyViewStateToTransform } from '../utils/transform';
+
+export type ProxyTransform = Transform & {
+  $internalUpdate: boolean;
+  $proposedTransform: Transform | null;
+  $reactViewState: Partial<ViewState>;
+};
+
+// These are Transform class methods that should not trigger any proxied getter/setter
+// See https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/handler_manager.ts
+const unproxiedMethods = new Set([
+  '_calcMatrices',
+  '_calcFogMatrices',
+  '_updateCameraState',
+  '_updateSeaLevelZoom'
+]);
+
+/**
+ * Mapbox map is stateful.
+ * During method calls/user interactions, map.transform is mutated and
+ * deviate from user-supplied props.
+ * In order to control the map reactively, we trap the transform mutations
+ * with a proxy, which reflects the view state resolved from
+ * both user-supplied props and the underlying state
+ */
+export function createProxyTransform(tr: Transform): ProxyTransform {
+  let internalUpdate = false;
+  let reactViewState: Partial<ViewState> = {};
+  /**
+   * Reflects view state set by react props
+   * This is the transform seen by painter, style etc.
+   */
+  const controlledTransform: Transform = tr;
+  /** Populated during camera move (handler/easeTo) if there is a discrepency between react props and proposed view state
+   * This is the transform seen by input handlers
+   */
+  let proposedTransform: Transform | null = null;
+
+  const handlers: ProxyHandler<Transform> = {
+    get(target: Transform, prop: string) {
+      // Props added by us
+      if (prop === '$reactViewState') {
+        return reactViewState;
+      }
+      if (prop === '$proposedTransform') {
+        return proposedTransform;
+      }
+      if (prop === '$internalUpdate') {
+        return internalUpdate;
+      }
+
+      // Ugly - this is indirectly called from HandlerManager bypassing zoom setter
+      if (prop === '_setZoom') {
+        return (z: number) => {
+          if (internalUpdate) {
+            proposedTransform?.[prop](z);
+          }
+          if (!Number.isFinite(reactViewState.zoom)) {
+            controlledTransform[prop](z);
+          }
+        };
+      }
+
+      if (
+        internalUpdate &&
+        prop === '_translateCameraConstrained' &&
+        Number.isFinite(reactViewState.zoom)
+      ) {
+        // mapbox is about to start mutating transform, and the view state is controlled by React props
+        proposedTransform = proposedTransform || controlledTransform.clone();
+      }
+
+      // When this function is executed, it updates both transforms respectively
+      if (unproxiedMethods.has(prop)) {
+        return function (...parms: unknown[]) {
+          proposedTransform?.[prop](...parms);
+          controlledTransform[prop](...parms);
+        };
+      }
+      if (internalUpdate && proposedTransform) {
+        return proposedTransform[prop];
+      }
+      return controlledTransform[prop];
+    },
+
+    set(target: Transform, prop: string, value: unknown) {
+      // Props added by us
+      if (prop === '$reactViewState') {
+        reactViewState = value as Partial<ViewState>;
+        applyViewStateToTransform(controlledTransform, reactViewState);
+        return true;
+      }
+      if (prop === '$proposedTransform') {
+        proposedTransform = value as Transform;
+        return true;
+      }
+      if (prop === '$internalUpdate') {
+        internalUpdate = value as boolean;
+        return true;
+      }
+
+      // Controlled props
+      let controlledValue = value;
+      if (prop === 'center' || prop === '_center') {
+        // @ts-expect-error LngLat constructor is not typed
+        controlledValue = new value.constructor(value.lng, value.lat);
+        if (Number.isFinite(reactViewState.longitude)) {
+          (controlledValue as LngLat).lng = reactViewState.longitude;
+        }
+        if (Number.isFinite(reactViewState.latitude)) {
+          (controlledValue as LngLat).lat = reactViewState.latitude;
+        }
+      } else if (prop === 'zoom' || prop === '_zoom' || prop === '_seaLevelZoom') {
+        if (Number.isFinite(reactViewState.zoom)) {
+          controlledValue = controlledTransform[prop];
+        }
+      } else if (prop === '_centerAltitude') {
+        if (Number.isFinite(reactViewState.altitude)) {
+          controlledValue = controlledTransform[prop];
+        }
+      } else if (prop === 'pitch' || prop === '_pitch') {
+        if (Number.isFinite(reactViewState.pitch)) {
+          controlledValue = controlledTransform[prop];
+        }
+      } else if (prop === 'bearing' || prop === 'rotation' || prop === 'angle') {
+        if (Number.isFinite(reactViewState.bearing)) {
+          controlledValue = controlledTransform[prop];
+        }
+      }
+
+      if (internalUpdate && proposedTransform) {
+        proposedTransform[prop] = value;
+      }
+
+      controlledTransform[prop] = controlledValue;
+      return true;
+    }
+  };
+  return new Proxy(tr, handlers) as ProxyTransform;
+}

--- a/modules/react-mapbox/src/mapbox/proxy-transform.ts
+++ b/modules/react-mapbox/src/mapbox/proxy-transform.ts
@@ -120,7 +120,7 @@ export function createProxyTransform(tr: Transform): ProxyTransform {
           controlledValue = controlledTransform[prop];
         }
       } else if (prop === '_centerAltitude') {
-        if (Number.isFinite(reactViewState.altitude)) {
+        if (Number.isFinite(reactViewState.elevation)) {
           controlledValue = controlledTransform[prop];
         }
       } else if (prop === 'pitch' || prop === '_pitch') {

--- a/modules/react-mapbox/src/types/common.ts
+++ b/modules/react-mapbox/src/types/common.ts
@@ -27,6 +27,8 @@ export type ViewState = {
   pitch: number;
   /** Dimensions in pixels applied on each side of the viewport for shifting the vanishing point. */
   padding: PaddingOptions;
+  /** Center elevation on terrain */
+  altitude?: number;
 };
 
 export interface ImmutableLike<T> {

--- a/modules/react-mapbox/src/types/common.ts
+++ b/modules/react-mapbox/src/types/common.ts
@@ -28,7 +28,7 @@ export type ViewState = {
   /** Dimensions in pixels applied on each side of the viewport for shifting the vanishing point. */
   padding: PaddingOptions;
   /** Center elevation on terrain */
-  altitude?: number;
+  elevation?: number;
 };
 
 export interface ImmutableLike<T> {

--- a/modules/react-mapbox/src/utils/transform.ts
+++ b/modules/react-mapbox/src/utils/transform.ts
@@ -18,6 +18,20 @@ export function transformToViewState(tr: Transform): ViewState {
   };
 }
 
+/** Returns `true` if the given props can potentially override view state updates */
+export function isViewStateControlled(v: Partial<ViewState>): boolean {
+  return (
+    Number.isFinite(v.longitude) ||
+    Number.isFinite(v.latitude) ||
+    Number.isFinite(v.zoom) ||
+    Number.isFinite(v.pitch) ||
+    Number.isFinite(v.bearing)
+  );
+}
+
+/**
+ * Returns `true` if transform needs to be updated to match view state
+ */
 export function compareViewStateWithTransform(tr: Transform, v: Partial<ViewState>): boolean {
   if (Number.isFinite(v.longitude) && tr.center.lng !== v.longitude) {
     return true;

--- a/modules/react-mapbox/src/utils/transform.ts
+++ b/modules/react-mapbox/src/utils/transform.ts
@@ -14,7 +14,7 @@ export function transformToViewState(tr: Transform): ViewState {
     pitch: tr.pitch,
     bearing: tr.bearing,
     padding: tr.padding,
-    altitude: tr._centerAltitude
+    elevation: tr._centerAltitude
   };
 }
 
@@ -86,7 +86,7 @@ export function applyViewStateToTransform(tr: Transform, v: Partial<ViewState>) 
     tr._center = new center.constructor(v.longitude ?? center.lng, v.latitude ?? center.lat);
   }
   if (Number.isFinite(v.zoom)) {
-    tr._centerAltitude = v.altitude ?? 0;
+    tr._centerAltitude = v.elevation ?? 0;
     if (tr.elevation) {
       tr._seaLevelZoom = v.zoom;
       const mercatorElevation = (tr.pixelsPerMeter / tr.worldSize) * tr._centerAltitude;

--- a/modules/react-mapbox/src/utils/transform.ts
+++ b/modules/react-mapbox/src/utils/transform.ts
@@ -1,35 +1,5 @@
-import type {MapboxProps} from '../mapbox/mapbox';
 import type {ViewState} from '../types/common';
 import type {Transform} from '../types/internal';
-import {deepEqual} from './deep-equal';
-
-/**
- * Make a copy of a transform
- * @param tr
- */
-export function cloneTransform(tr: Transform): Transform {
-  const newTransform = tr.clone();
-  // Work around mapbox bug - this value is not assigned in clone(), only in resize()
-  newTransform.pixelsToGLUnits = tr.pixelsToGLUnits;
-  return newTransform;
-}
-
-/**
- * Copy projection from one transform to another. This only applies to mapbox-gl transforms
- * @param src the transform to copy projection settings from
- * @param dest to transform to copy projection settings to
- */
-export function syncProjection(src: Transform, dest: Transform): void {
-  if (!src.getProjection) {
-    return;
-  }
-  const srcProjection = src.getProjection();
-  const destProjection = dest.getProjection();
-
-  if (!deepEqual(srcProjection, destProjection)) {
-    dest.setProjection(srcProjection);
-  }
-}
 
 /**
  * Capture a transform's current state
@@ -40,48 +10,87 @@ export function transformToViewState(tr: Transform): ViewState {
   return {
     longitude: tr.center.lng,
     latitude: tr.center.lat,
-    zoom: tr.zoom,
+    zoom: tr._seaLevelZoom ?? tr.zoom,
     pitch: tr.pitch,
     bearing: tr.bearing,
-    padding: tr.padding
+    padding: tr.padding,
+    altitude: tr._centerAltitude
   };
 }
 
-/* eslint-disable complexity */
-/**
- * Mutate a transform to match the given view state
- * @param transform
- * @param viewState
- * @returns true if the transform has changed
- */
-export function applyViewStateToTransform(tr: Transform, props: MapboxProps): boolean {
-  const v: Partial<ViewState> = props.viewState || props;
-  let changed = false;
-
-  if ('zoom' in v) {
-    const zoom = tr.zoom;
-    tr.zoom = v.zoom;
-    changed = changed || zoom !== tr.zoom;
+export function compareViewStateWithTransform(tr: Transform, v: Partial<ViewState>): boolean {
+  if (Number.isFinite(v.longitude) && tr.center.lng !== v.longitude) {
+    return true;
   }
-  if ('bearing' in v) {
-    const bearing = tr.bearing;
-    tr.bearing = v.bearing;
-    changed = changed || bearing !== tr.bearing;
+  if (Number.isFinite(v.latitude) && tr.center.lat !== v.latitude) {
+    return true;
   }
-  if ('pitch' in v) {
-    const pitch = tr.pitch;
-    tr.pitch = v.pitch;
-    changed = changed || pitch !== tr.pitch;
+  if (Number.isFinite(v.bearing) && tr.bearing !== v.bearing) {
+    return true;
+  }
+  if (Number.isFinite(v.pitch) && tr.pitch !== v.pitch) {
+    return true;
+  }
+  if (Number.isFinite(v.zoom) && (tr._seaLevelZoom ?? tr.zoom) !== v.zoom) {
+    return true;
   }
   if (v.padding && !tr.isPaddingEqual(v.padding)) {
-    changed = true;
+    return true;
+  }
+  return false;
+}
+
+function noOp() {}
+
+/* eslint-disable complexity */
+/**
+ * Mutate a transform to match the given view state. Should reverse `transformToViewState`
+ * @param transform
+ * @param viewState
+ */
+export function applyViewStateToTransform(tr: Transform, v: Partial<ViewState>) {
+  // prevent constrain from running until all properties are set
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const constrain = tr._constrain;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const calcMatrices = tr._calcMatrices;
+  tr._constrain = noOp;
+  tr._calcMatrices = noOp;
+
+  if (Number.isFinite(v.bearing)) {
+    tr.bearing = v.bearing;
+  }
+  if (Number.isFinite(v.pitch)) {
+    tr.pitch = v.pitch;
+  }
+  if (v.padding && !tr.isPaddingEqual(v.padding)) {
     tr.padding = v.padding;
   }
-  if ('longitude' in v && 'latitude' in v) {
+  if (Number.isFinite(v.longitude) || Number.isFinite(v.latitude)) {
     const center = tr.center;
-    // @ts-ignore
-    tr.center = new center.constructor(v.longitude, v.latitude);
-    changed = changed || center !== tr.center;
+    // @ts-expect-error LngLat constructor is not typed
+    tr._center = new center.constructor(v.longitude ?? center.lng, v.latitude ?? center.lat);
   }
-  return changed;
+  if (Number.isFinite(v.zoom)) {
+    tr._centerAltitude = v.altitude ?? 0;
+    if (tr.elevation) {
+      tr._seaLevelZoom = v.zoom;
+      const mercatorElevation = (tr.pixelsPerMeter / tr.worldSize) * tr._centerAltitude;
+      const altitude = tr._mercatorZfromZoom(v.zoom);
+      const minHeight = tr._mercatorZfromZoom(tr._maxZoom);
+      const height = Math.max(altitude - mercatorElevation, minHeight);
+      tr._setZoom(tr._zoomFromMercatorZ(height));
+    } else {
+      tr._seaLevelZoom = null;
+      tr.zoom = v.zoom;
+    }
+  }
+
+  // restore methods
+  tr._constrain = constrain;
+  tr._calcMatrices = calcMatrices;
+  if (!tr._unmodified) {
+    tr._constrain();
+    tr._calcMatrices();
+  }
 }

--- a/modules/react-mapbox/test/utils/mapbox-gl-mock/transform.js
+++ b/modules/react-mapbox/test/utils/mapbox-gl-mock/transform.js
@@ -20,6 +20,7 @@ export default class Transform {
     this.angle = 0;
     this._pitch = 0;
     this._edgeInsets = new EdgeInsets();
+    this._centerAltitude = 0;
   }
 
   get bearing() {
@@ -88,4 +89,8 @@ export default class Transform {
   isPaddingEqual(padding) {
     return this._edgeInsets.equals(padding);
   }
+
+  _constrain() {}
+
+  _calcMatrices() {}
 }

--- a/modules/react-mapbox/test/utils/transform.spec.js
+++ b/modules/react-mapbox/test/utils/transform.spec.js
@@ -1,6 +1,7 @@
 import test from 'tape-promise/tape';
 import {
   transformToViewState,
+  compareViewStateWithTransform,
   applyViewStateToTransform
 } from '@vis.gl/react-mapbox/utils/transform';
 
@@ -8,11 +9,14 @@ import Transform from './mapbox-gl-mock/transform';
 
 test('applyViewStateToTransform', t => {
   const tr = new Transform();
-
-  let changed = applyViewStateToTransform(tr, {});
+  let viewState = {};
+  let changed = compareViewStateWithTransform(tr, viewState);
+  applyViewStateToTransform(tr, viewState);
   t.notOk(changed, 'empty view state');
 
-  changed = applyViewStateToTransform(tr, {longitude: -10, latitude: 5});
+  viewState = {longitude: -10, latitude: 5};
+  changed = compareViewStateWithTransform(tr, viewState);
+  applyViewStateToTransform(tr, viewState);
   t.ok(changed, 'center changed');
   t.deepEqual(
     transformToViewState(tr),
@@ -22,15 +26,15 @@ test('applyViewStateToTransform', t => {
       zoom: 0,
       pitch: 0,
       bearing: 0,
-      padding: {left: 0, right: 0, top: 0, bottom: 0}
+      padding: {left: 0, right: 0, top: 0, bottom: 0},
+      altitude: 0
     },
     'view state is correct'
   );
 
-  changed = applyViewStateToTransform(tr, {zoom: -1});
-  t.notOk(changed, 'zoom is clamped');
-
-  changed = applyViewStateToTransform(tr, {zoom: 10});
+  viewState = {zoom: 10};
+  changed = compareViewStateWithTransform(tr, viewState);
+  applyViewStateToTransform(tr, viewState);
   t.ok(changed, 'zoom changed');
   t.deepEqual(
     transformToViewState(tr),
@@ -40,12 +44,15 @@ test('applyViewStateToTransform', t => {
       zoom: 10,
       pitch: 0,
       bearing: 0,
-      padding: {left: 0, right: 0, top: 0, bottom: 0}
+      padding: {left: 0, right: 0, top: 0, bottom: 0},
+      altitude: 0
     },
     'view state is correct'
   );
 
-  changed = applyViewStateToTransform(tr, {pitch: 30});
+  viewState = {pitch: 30};
+  changed = compareViewStateWithTransform(tr, viewState);
+  applyViewStateToTransform(tr, viewState);
   t.ok(changed, 'pitch changed');
   t.deepEqual(
     transformToViewState(tr),
@@ -55,12 +62,15 @@ test('applyViewStateToTransform', t => {
       zoom: 10,
       pitch: 30,
       bearing: 0,
-      padding: {left: 0, right: 0, top: 0, bottom: 0}
+      padding: {left: 0, right: 0, top: 0, bottom: 0},
+      altitude: 0
     },
     'view state is correct'
   );
 
-  changed = applyViewStateToTransform(tr, {bearing: 270});
+  viewState = {bearing: 270};
+  changed = compareViewStateWithTransform(tr, viewState);
+  applyViewStateToTransform(tr, viewState);
   t.ok(changed, 'bearing changed');
   t.deepEqual(
     transformToViewState(tr),
@@ -70,12 +80,15 @@ test('applyViewStateToTransform', t => {
       zoom: 10,
       pitch: 30,
       bearing: -90,
-      padding: {left: 0, right: 0, top: 0, bottom: 0}
+      padding: {left: 0, right: 0, top: 0, bottom: 0},
+      altitude: 0
     },
     'view state is correct'
   );
 
-  changed = applyViewStateToTransform(tr, {padding: {left: 10, right: 10, top: 10, bottom: 10}});
+  viewState = {padding: {left: 10, right: 10, top: 10, bottom: 10}};
+  changed = compareViewStateWithTransform(tr, viewState);
+  applyViewStateToTransform(tr, viewState);
   t.ok(changed, 'padding changed');
   t.deepEqual(
     transformToViewState(tr),
@@ -85,16 +98,22 @@ test('applyViewStateToTransform', t => {
       zoom: 10,
       pitch: 30,
       bearing: -90,
-      padding: {left: 10, right: 10, top: 10, bottom: 10}
+      padding: {left: 10, right: 10, top: 10, bottom: 10},
+      altitude: 0
     },
     'view state is correct'
   );
 
-  changed = applyViewStateToTransform(tr, {viewState: {pitch: 30}});
+  viewState = {pitch: 30};
+  changed = compareViewStateWithTransform(tr, viewState);
+  applyViewStateToTransform(tr, viewState);
   t.notOk(changed, 'nothing changed');
 
   applyViewStateToTransform(tr, {longitude: 0, latitude: 0, zoom: 0});
-  changed = applyViewStateToTransform(tr, {longitude: 12, latitude: 34, zoom: 15});
+
+  viewState = {longitude: 12, latitude: 34, zoom: 15};
+  changed = compareViewStateWithTransform(tr, viewState);
+  applyViewStateToTransform(tr, viewState);
   t.ok(changed, 'center and zoom changed');
   t.equal(tr.zoom, 15, 'zoom is correct');
   t.equal(tr.center.lat, 34, 'center latitude is correct');

--- a/modules/react-mapbox/test/utils/transform.spec.js
+++ b/modules/react-mapbox/test/utils/transform.spec.js
@@ -27,7 +27,7 @@ test('applyViewStateToTransform', t => {
       pitch: 0,
       bearing: 0,
       padding: {left: 0, right: 0, top: 0, bottom: 0},
-      altitude: 0
+      elevation: 0
     },
     'view state is correct'
   );
@@ -45,7 +45,7 @@ test('applyViewStateToTransform', t => {
       pitch: 0,
       bearing: 0,
       padding: {left: 0, right: 0, top: 0, bottom: 0},
-      altitude: 0
+      elevation: 0
     },
     'view state is correct'
   );
@@ -63,7 +63,7 @@ test('applyViewStateToTransform', t => {
       pitch: 30,
       bearing: 0,
       padding: {left: 0, right: 0, top: 0, bottom: 0},
-      altitude: 0
+      elevation: 0
     },
     'view state is correct'
   );
@@ -81,7 +81,7 @@ test('applyViewStateToTransform', t => {
       pitch: 30,
       bearing: -90,
       padding: {left: 0, right: 0, top: 0, bottom: 0},
-      altitude: 0
+      elevation: 0
     },
     'view state is correct'
   );
@@ -99,7 +99,7 @@ test('applyViewStateToTransform', t => {
       pitch: 30,
       bearing: -90,
       padding: {left: 10, right: 10, top: 10, bottom: 10},
-      altitude: 0
+      elevation: 0
     },
     'view state is correct'
   );


### PR DESCRIPTION
This is a pretty big change to how we handle controlled Mapbox instance.

## Background 

The basis of our approach is that we keep two Transform instances: one that Map can mutate freely, and one that is controlled by React props.

In 7.x and 8.0, we created a `renderTransform` as the controlled instance. The mutable instance is the permanent source of truth of the map state. Its changes are merged with React props and synchronized back to `renderTransform`. During 1. render, 2. query and 3. event callbacks, `renderTransform` is swapped in so the map reads the controlled matrices.

We have made a lot of hacks and patches around this approach, and there still are a handful of long-standing issues, mostly around terrain and non-mercator projection. The source of the grievance is that
1. Mapbox can mutate `map.transform` on various lifecycle stages and some of them do not trigger an event.
2. Transform cannot be deterministically reproduced by its public methods and from a ViewState object. Terrain mutates unexposed private fields that affect matrix calculation (#2194, #2088, #2248). New features can also fail to be synchronized (#2506).

## Changes

This PR proposes a (hopefully) cleaner approach. We replace `map.transform` with a `ProxyTransform`, which uses [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to trap get and set operations. Under the hood, it manages the two Transform instances (freely mutable `proposedTransform` and React-controlled `controlledTransform`). Of the two, `controlledTransform` is the permanent source of truth, and `proposedTransform` is only temporarily populated IF the map is controlled AND during a move session. This results in much better consistency in map behavior:
1. In the uncontrolled use case (using `initialViewState`) there is only one transform instance, which should minimize the perf/bugs impact from our wrapper
2. No more instance swapping, which should eliminate the discrepancy in behavior between GL renderer, DOM controls and query.

I am also trying to document inline extensively to improve code readability.

## Release plan

Targeting a v8.1 release.
I am leaning towards NOT back porting this to `mapbox-legacy`, which is mainly used for mapbox-gl@1 and will be eventually deprecated. The old approach works fairly well for the basic (no terrain or alt projection) use case. The new approach relies heavily on the internals of the `Transform` class and the official types. I did a quick audit and most of the private methods have existed since v2.0. However we do not test with non-latest mapbox versions and it could become a maintenance hazard.
