### PR TITLE
fix(geocoder): add styles for example

### DIFF
--- a/examples/mapbox/geocoder/src/geocoder-control.tsx
+++ b/examples/mapbox/geocoder/src/geocoder-control.tsx
@@ -3,6 +3,8 @@ import {useState} from 'react';
 import {useControl, Marker, MarkerProps, ControlPosition} from 'react-map-gl/mapbox';
 import MapboxGeocoder, {GeocoderOptions} from '@mapbox/mapbox-gl-geocoder';
 
+import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
+
 type GeocoderControlProps = Omit<GeocoderOptions, 'accessToken' | 'mapboxgl' | 'marker'> & {
   mapboxAccessToken: string;
   marker?: boolean | Omit<MarkerProps, 'longitude' | 'latitude'>;


### PR DESCRIPTION
The example is missing the default `@mapbox/mapbox-gl-geocoder` styles.

<img width="348" alt="image" src="https://github.com/user-attachments/assets/9aa2c582-f72c-4e96-956a-370dabbe7527" />

<img width="318" alt="image" src="https://github.com/user-attachments/assets/e83e001a-75e4-49bb-9a94-2099e4117002" />
