### PR TITLE
Use name of defined component

### DIFF
--- a/docs/api-reference/maplibre/use-map.md
+++ b/docs/api-reference/maplibre/use-map.md
@@ -9,7 +9,7 @@ import {Map, useMap} from 'react-map-gl/maplibre';
 function Root() {
   return (
     <Map ... >
-      <NavigationButton />
+      <NavigateButton />
     </Map>
   );
 }


### PR DESCRIPTION
In this example, NavigateButton is defined, not NavigationButton. So we should call NavigateButton!