### PR TITLE
fix: max depth exceeded error when dynamically changing map settings

### DIFF
--- a/modules/react-mapbox/src/mapbox/mapbox.ts
+++ b/modules/react-mapbox/src/mapbox/mapbox.ts
@@ -216,9 +216,6 @@ export default class Mapbox {
     this.props = props;
 
     const settingsChanged = this._updateSettings(props, oldProps);
-    if (settingsChanged) {
-      this._createProxyTransform(this._map);
-    }
     const sizeChanged = this._updateSize(props);
     const viewStateChanged = this._updateViewState(props, true);
     this._updateStyle(props, oldProps);

--- a/modules/react-mapbox/test/components/map.spec.jsx
+++ b/modules/react-mapbox/test/components/map.spec.jsx
@@ -147,6 +147,42 @@ test('Map#controlled#no-update', t => {
   );
 });
 
+test('Map#uncontrolled#delayedSettingsUpdate', async t => {
+  const root = createRoot(document.createElement('div'));
+  const mapRef = {current: null};
+
+  function App() {
+    const [settings, setSettings] = React.useState({
+      maxPitch: 85
+    });
+
+    async function onLoad() {
+      await sleep(1);
+      setSettings({maxPitch: 60});
+    }
+
+    return (
+      <Map
+        ref={mapRef}
+        mapLib={import('mapbox-gl-v3')}
+        mapboxAccessToken={MapboxAccessToken}
+        initialViewState={{longitude: -100, latitude: 40, zoom: 4}}
+        {...settings}
+        onLoad={() => {
+          onLoad();
+        }}
+      />
+    );
+  }
+
+  root.render(<App />);
+
+  await waitForMapLoad(mapRef);
+  await sleep(1);
+
+  t.is(mapRef.current.getMaxPitch(), 60, 'maxPitch is updated');
+});
+
 test('Map#controlled#mirror-back', t => {
   const root = createRoot(document.createElement('div'));
   const mapRef = {current: null};


### PR DESCRIPTION
stems from an issue found in https://github.com/visgl/react-map-gl/issues/2194#issuecomment-2878158442

When we check for if settings changed a new proxy transform is instantiated, but a previously instantiated proxy was already created and assigned to the argument. This call just created a proxy of the proxy (and kept doing so, hence the stack error) - I think we could just keep the original proxy object without reinstantiating.

Added a spec to dynamically update map settings after initial render to catch this.


Before:

https://github.com/user-attachments/assets/14a76a5d-7b3d-44e3-b4de-f4e695c47521 

After:

https://github.com/user-attachments/assets/996fe4a8-1dcb-44e2-b256-5f19502a9345

