### PR TITLE
feat: Add GlobeControl for maplibre

### DIFF
--- a/docs/api-reference/maplibre/globe-control.md
+++ b/docs/api-reference/maplibre/globe-control.md
@@ -1,0 +1,44 @@
+# GlobeControl
+
+React component that wraps maplibre-gl's [GlobeControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/GlobeControl/) class.
+
+```tsx
+import * as React from 'react';
+import {Map, GlobeControl} from 'react-map-gl/maplibre';
+import 'maplibre-gl/dist/maplibre-gl.css';
+
+function App() {
+  return <Map
+    initialViewState={{
+      longitude: -100,
+      latitude: 40,
+      zoom: 3.5
+    }}
+    mapStyle="https://demotiles.maplibre.org/style.json"
+  >
+    <GlobeControl />
+  </Map>;
+}
+```
+
+## Properties
+
+### Reactive Properties
+
+#### `style`: CSSProperties {#style}
+
+CSS style override that applies to the control's container.
+
+### Other Properties
+
+The properties in this section are not reactive. They are only used when the component first mounts.
+
+#### `position`: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' {#position}
+
+Default: `'top-right'`
+
+Placement of the control relative to the map.
+
+## Source
+
+[globe-control.ts](https://github.com/visgl/react-map-gl/tree/9.0-release/modules/react-maplibre/src/components/globe-control.ts)

--- a/modules/react-maplibre/src/components/globe-control.ts
+++ b/modules/react-maplibre/src/components/globe-control.ts
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { useEffect, memo } from "react";
+import { applyReactStyle } from "../utils/apply-react-style";
+import { useControl } from "./use-control";
+import { ControlPosition } from "../types/lib";
+
+export type GlobeControlProps = {
+  /** Placement of the control relative to the map. */
+  position?: ControlPosition;
+  /** CSS style override, applied to the control's container */
+  style?: React.CSSProperties;
+};
+
+function _GlobeControl(props: GlobeControlProps) {
+  const ctrl = useControl(({ mapLib }) => new mapLib.GlobeControl(props), {
+    position: props.position,
+  });
+
+  useEffect(() => {
+    applyReactStyle(ctrl._container, props.style);
+  }, [props.style]);
+
+  return null;
+}
+
+export const GlobeControl = memo(_GlobeControl);

--- a/modules/react-maplibre/src/types/lib.ts
+++ b/modules/react-maplibre/src/types/lib.ts
@@ -18,7 +18,8 @@ import type {
   TerrainControl,
   TerrainSpecification,
   LogoControl,
-  LogoControlOptions
+  LogoControlOptions,
+  GlobeControl,
 } from 'maplibre-gl';
 
 export type {
@@ -43,6 +44,7 @@ export type {
   TerrainControl as TerrainControlInstance,
   LogoControl as LogoControlInstance,
   LogoControlOptions,
+  GlobeControl as GlobeControlInstance,
   CustomLayerInterface
 } from 'maplibre-gl';
 
@@ -73,4 +75,6 @@ export interface MapLib {
   TerrainControl: {new (options: TerrainSpecification): TerrainControl};
 
   LogoControl: {new (options: LogoControlOptions): LogoControl};
+
+  GlobeControl: {new (options: any): GlobeControl};
 }


### PR DESCRIPTION
## What

maplibre-gl-js has officially added GlobeControl:
https://maplibre.org/maplibre-gl-js/docs/API/classes/GlobeControl/

This pull request enables the use of GlobeControl in react-map-gl as well.

### Intended behavior

- [x] When you click GlobeControl button, the projection of map should be change to "globe".
- [x] When you click GlobeControl button once again, the projection of map should be change to "mercator".

### Screen record

https://github.com/user-attachments/assets/7baad9ed-5b62-425b-a48f-21971425d5e7



## Why

I love using react-map-gl when developing interactive map applications by combining React and maplibre-gl-js.
Since GlobeControl does not exist on react-map-gl, I am implementing it myself:
https://github.com/yuiseki/TRIDENT/blob/main/src/components/GlobeControl/index.ts

This implementation is a custom extension that follows the existing GeolocateControl and NavigationControl on react-map-gl.
I am submitting a pull request because I would very much like to use this as an official component of react-map-gl.

## How

The following files have been added:
- modules/react-maplibre/src/components/globe-control.ts
- docs/api-reference/maplibre/globe-control.md

The following files have been modified:
- modules/react-maplibre/src/types/lib.ts


### PR Checklist

- [x] Tests
- `yarn test` must be successful.
  + New code should be covered by unit tests whenever possible.
- [x] Documentation
  + If public APIs are added/modified, update component documentation in `docs/api-reference`.
  + Breaking changes and deprecations must be added to `docs/upgrade-guide.md`.
  + Noteworthy new features should be added to `docs/whats-new.md`.
- [x] Description on GitHub
  + Link to relevant issue.
  + Label with a milestone (latest release or vNext).
  + If public APIs are added/modified, describe the intended behavior.
  + If visual/interaction is affected, consider attaching a screenshot/GIF.